### PR TITLE
Add a DIN pin to Audio::setPinout.

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -39,7 +39,7 @@ Audio::Audio() {
     m_BCLK=26;                       // Bit Clock
     m_LRC=25;                        // Left/Right Clock
     m_DOUT=27;                       // Data Out
-    setPinout(m_BCLK, m_LRC, m_DOUT);
+    setPinout(m_BCLK, m_LRC, m_DOUT, m_DIN);
 
 }
 
@@ -1562,16 +1562,17 @@ int Audio::sendBytes(uint8_t *data, size_t len) {
     return bytesDecoded;
 }
 //---------------------------------------------------------------------------------------------------------------------
-bool Audio::setPinout(uint8_t BCLK, uint8_t LRC, uint8_t DOUT){
+bool Audio::setPinout(uint8_t BCLK, uint8_t LRC, uint8_t DOUT, uint8_t DIN){
     m_BCLK=BCLK;            // Bit Clock
     m_LRC=LRC;              // Left/Right Clock
     m_DOUT=DOUT;            // Data Out
+    m_DIN=DIN;              // Data In
 
     i2s_pin_config_t pins = {
       .bck_io_num = m_BCLK,
       .ws_io_num =  m_LRC,              //  wclk,
       .data_out_num = m_DOUT,
-      .data_in_num = I2S_PIN_NO_CHANGE
+      .data_in_num = m_DIN
     };
     i2s_set_pin((i2s_port_t)m_i2s_num, &pins);
     return true;

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -72,7 +72,7 @@ public:
      * @return true if audio file active and speed is valid, otherwise false
      */
     bool audioFileSeek(const int8_t speed);
-    bool setPinout(uint8_t BCLK, uint8_t LRC, uint8_t DOUT);
+    bool setPinout(uint8_t BCLK, uint8_t LRC, uint8_t DOUT, uint8_t DIN=I2S_PIN_NO_CHANGE);
     void stopSong();
     /**
      * @brief pauseResume pauses current playback 
@@ -140,6 +140,7 @@ private:
     uint8_t         m_BCLK=0;                       // Bit Clock
     uint8_t         m_LRC=0;                        // Left/Right Clock
     uint8_t         m_DOUT=0;                       // Data Out
+    uint8_t         m_DIN=0;                        // Data In
     uint8_t         m_vol=64;                       // volume
     uint8_t         m_bps;                          // bitsPerSample
     uint8_t         m_channels;


### PR DESCRIPTION
Hi Wolle
This PR aims to add support for boards with I2S recording capability.

Currently I am testing it on a [M5Stack Node](https://github.com/m5stack/Bases-Node).
Support for `I2S_DIN` is working.
These boards also need a MCLK signal on GPIO0.
That is not yet working in this PR.

Maybe you can shed some light on how to solve that.
I use this sketch to setup the board now:
```c++
// M5Stack Node pins https://github.com/m5stack/Bases-Node

#define I2C_SDA  21
#define I2C_SCL  22

/* M5Stack Node WM8978 pins */ 
//      codec pin    esp32 pin
#define I2S_BCK      5
#define I2S_WS      13
#define I2S_DOUT     2  
#define I2S_DIN     34   
#define I2S_MCLK     0

#include "Audio.h"
#include "WM8978.h"
#include "I2S.h"

Audio audio;

void setup() {
  WiFi.begin("xxx", "xxx");
  while (!WiFi.isConnected()) {
    delay(10);
  }
  ESP_LOGI(TAG, "Connected");

  //init wm8978 I2C interface
  wm8978Setup(I2C_SDA, I2C_SCL);

  //set clock on pin 0 - https://www.esp32.com/viewtopic.php?t=3060
  PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
  //REG_WRITE(PIN_CTRL, 0xFFFFFFF0);
  REG_WRITE(PIN_CTRL, 0);
  
  audio.setPinout(I2S_BCK, I2S_WS, I2S_DOUT, I2S_DIN);

  ESP_LOGI(TAG, "Starting MP3...\n");
  audio.connecttohost("http://icecast.omroep.nl/3fm-bb-mp3");
  
  WM8978_SPKvol_Set(40); /* max 63? */
  WM8978_HPvol_Set(32,32);  
}

void loop() {
  audio.loop();
  //delay(2);
}
```
