### PR TITLE
ID3 Parsing: force APIC tags to be non-unicode

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -500,6 +500,7 @@ void Audio::readID3Metadata(){
                 else{
                     if(tag=="APIC"){ // a image embedded in file, skip it
                         //log_i("it's a image");
+                        isUnicode = false;
                         setFilePos(getFilePos()+framesize-1); id3Size-=framesize-1;
                     }
                     else{


### PR DESCRIPTION
If an ID3 tag containing an image sets the unicode bit, the current code goes
into an infinite loop on line 516. Since converting unicode characters on an
image doesn't make sense anyway, this patch forces image tags to be non-unicode.

The problem appears with several mp3 files downloaded from jamendo. This patch
allows to play them.