### PR TITLE
Stop on end

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -902,20 +902,9 @@ void Audio::processWebStream()
 
         if ( m_f_firststream_ready == true )
         {
-            static uint32_t loopCnt = 0;      // Count loops if clientbuffer is empty
             if ( availableBytes == 0 )
-            {   // empty buffer, broken stream or bad bitrate?
-                loopCnt++;
-                if( loopCnt > 200000 )
-                {  // wait several seconds
-                    loopCnt = 0;
-                    if(audio_info) audio_info("Stream lost -> try new connection");
-                    connecttohost(m_lastHost); // try a new connection
-                }
-            }
-            else
             {
-                loopCnt = 0;
+                stopSong();
             }
         }
 

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -905,8 +905,7 @@ void Audio::processWebStream()
             if ( availableBytes == 0 )
             {
                 stopSong();
-                sprintf(chbuf, "Stream end");
-                if(audio_info) audio_info(chbuf);
+                if(audio_info) audio_info("Stream end");
             }
         }
 

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -905,7 +905,7 @@ void Audio::processWebStream()
             if ( availableBytes == 0 )
             {
                 stopSong();
-                if (audio_info) audio_info("Stream end");
+                if (audio_info) audio_info("Stream end: %s", m_lastHost);
             }
         }
 

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -905,7 +905,7 @@ void Audio::processWebStream()
             if ( availableBytes == 0 )
             {
                 stopSong();
-                if(audio_info) audio_info("Stream end");
+                if (audio_info) audio_info("Stream end");
             }
         }
 

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -905,8 +905,10 @@ void Audio::processWebStream()
             if ( availableBytes == 0 )
             {
                 stopSong();
-                sprintf(chbuf,"Stream lost: %s", m_lastHost);
-                if (audio_info) audio_info(chbuf);
+                if (audio_info) {
+                    sprintf(chbuf,"Stream lost: %s", m_lastHost.c_str());
+                    audio_info(chbuf);
+                }
             }
         }
 

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -905,6 +905,8 @@ void Audio::processWebStream()
             if ( availableBytes == 0 )
             {
                 stopSong();
+                sprintf(chbuf, "Stream end");
+                if(audio_info) audio_info(chbuf);
             }
         }
 

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -905,7 +905,8 @@ void Audio::processWebStream()
             if ( availableBytes == 0 )
             {
                 stopSong();
-                if (audio_info) audio_info("Stream end: %s", m_lastHost);
+                sprintf(chbuf,"Stream lost: %s", m_lastHost);
+                if (audio_info) audio_info(chbuf);
             }
         }
 


### PR DESCRIPTION
'Normal' mp3 files on a fileserver keep running on loop without this PR.

With this PR streams/files that end trigger stopSong() and a callback.