### PR TITLE
ID3 Parsing: Only convert unicode if framesize > 1

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -527,7 +527,7 @@ void Audio::readID3Metadata(){
                         setFilePos(getFilePos()+framesize-1-255); id3Size-=framesize-1;
                     }
                 }
-                if(isUnicode){  // convert unicode to utf-8 U+0020...U+07FF
+                if(isUnicode && framesize > 1){  // convert unicode to utf-8 U+0020...U+07FF
                     j=0; m=0;
                     while(m<i-1){
                         if((value[m]==0xFE)&&(value[m+1]==0xFF)){bitorder=true; j=m+2;}// MSB/LSB


### PR DESCRIPTION
The current id3 parsing code leads to a lock-up of the cpu if the
framesize is 1 and unicode conversion needs to be done. This is since

i = framesize -1

and the conversion loop condition is m<i-1. For framesize = 1 -> i=0 and
the condition m<-1 for unit16_t m keeps the cpu busy for a while and
reads way above the memory boundary of the array 'value' inside the loop.

This patch fixes the problem by not entering the unicode conversion if
the framesize is <= 1.