### PR TITLE
Set the pins (optionally) in the ctor.

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -127,8 +127,8 @@ uint32_t AudioBuffer::getReadPos(){
 }
 
 
-//---------------------------------------------------------------------------------------------------------------------
-Audio::Audio() {
+
+Audio::Audio(const uint8_t BCLK, const uint8_t LRC, const uint8_t DOUT) {
     //i2s configuration
     m_i2s_num = I2S_NUM_0; // i2s port number
     m_i2s_config.mode                 = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX);
@@ -145,9 +145,9 @@ Audio::Audio() {
 
     i2s_driver_install((i2s_port_t)m_i2s_num, &m_i2s_config, 0, NULL);
 
-    m_BCLK=26;                       // Bit Clock
-    m_LRC=25;                        // Left/Right Clock
-    m_DOUT=27;                       // Data Out
+    m_BCLK=BCLK;                       // Bit Clock
+    m_LRC=LRC;                         // Left/Right Clock
+    m_DOUT=DOUT;                       // Data Out
     setPinout(m_BCLK, m_LRC, m_DOUT, m_DIN);
 
     size_t size = InBuff.init();

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -125,9 +125,7 @@ uint32_t AudioBuffer::getWritePos(){
 uint32_t AudioBuffer::getReadPos(){
     return m_readPtr - m_buffer;
 }
-
-
-
+//---------------------------------------------------------------------------------------------------------------------
 Audio::Audio(const uint8_t BCLK, const uint8_t LRC, const uint8_t DOUT) {
     //i2s configuration
     m_i2s_num = I2S_NUM_0; // i2s port number

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -103,7 +103,7 @@ class Audio : private AudioBuffer{
     AudioBuffer InBuff; // instance of input buffer
 
 public:
-    Audio();
+    Audio(const uint8_t BCLK=25, const uint8_t LRC=26, const uint8_t DOUT=27);
     ~Audio();
     bool connecttoFS(fs::FS &fs, String file);
     bool connecttoSD(String sdfile);

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -103,7 +103,7 @@ class Audio : private AudioBuffer{
     AudioBuffer InBuff; // instance of input buffer
 
 public:
-    Audio(const uint8_t BCLK=25, const uint8_t LRC=26, const uint8_t DOUT=27);
+    Audio(const uint8_t BCLK=26, const uint8_t LRC=25, const uint8_t DOUT=27);
     ~Audio();
     bool connecttoFS(fs::FS &fs, String file);
     bool connecttoSD(String sdfile);


### PR DESCRIPTION
This should solve #70 and possibly CelliesProjects/wm8978-esp32/issues/4

So now you can use:
```c++
Audio audio(BCLK, LRC, DOUT);
```
as a constructor.
Or use
```c++
Audio audio;
```
as before and default to 26,25,27.

If no pins are given, the ctor will default to BLCK=26, LRC=25, DOUT=27.

This *should* be compatible with existing code.

M5Stack Node plays pretty good (On a Fire, not tested on Grey). 

The test sketches from ESP32-I2SAudio also work.

Please test this on M5Stack Node.
