### PR TITLE
Audio::setPinout returns a boolean 'true' even if the call to 'i2s_set_pin' fails.

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2021,7 +2021,7 @@ bool Audio::setPinout(uint8_t BCLK, uint8_t LRC, uint8_t DOUT, int8_t DIN){
       .data_out_num = m_DOUT,
       .data_in_num = m_DIN
     };
-    esp_err_t result = i2s_set_pin((i2s_port_t)m_i2s_num, &pins);
+    const esp_err_t result = i2s_set_pin((i2s_port_t)m_i2s_num, &pins);
     return (result == ESP_OK);
 }
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2021,8 +2021,8 @@ bool Audio::setPinout(uint8_t BCLK, uint8_t LRC, uint8_t DOUT, int8_t DIN){
       .data_out_num = m_DOUT,
       .data_in_num = m_DIN
     };
-    i2s_set_pin((i2s_port_t)m_i2s_num, &pins);
-    return true;
+    esp_err_t result = i2s_set_pin((i2s_port_t)m_i2s_num, &pins);
+    return (result == ESP_OK);
 }
 //---------------------------------------------------------------------------------------------------------------------
 uint32_t Audio::getFileSize(){


### PR DESCRIPTION
With this PR `Audio::setPinout` returns a `false` if the call to `i2s_set_pin` fails.

See https://github.com/schreibfaul1/ESP32-audioI2S/issues/70#issuecomment-715999934 about this issue.