### PR TITLE
added loop support for files

### DIFF
--- a/src/Audio.h
+++ b/src/Audio.h
@@ -107,6 +107,7 @@ public:
     ~Audio();
     bool connecttoFS(fs::FS &fs, String file);
     bool connecttoSD(String sdfile);
+    bool setFileLoop(bool input);//TEST loop
     bool connecttohost(String host, const char* user = "", const char* pwd = "");
     bool connecttospeech(String speech, String lang);
     void loop();
@@ -259,6 +260,11 @@ private:
     size_t          m_i2s_bytesWritten = 0;         // set in i2s_write() but not used
     uint32_t        m_audioFileDuration = 0;
     float           m_audioCurrentTime = 0;
+    //TEST loop
+    bool            m_f_loop = false;               // Set if audio file should loop
+    size_t          m_f_loop_point = 0;             // Point in the file where the audio data starts
+    size_t          m_f_file_size = 0;              // size of the file 
+    //TEST loop 
 };
 
 #endif /* AUDIO_H_ */


### PR DESCRIPTION
With these changes it is possible to loop a file without interrupting the playback.
What it does is save where the audio data starts in the file and when the eof is detected jump back to the start.
I've tested it with a few mp3 and wav files but it will need further testing.