### PR TITLE
Fix the current time of the loop mode is not reset

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -1424,6 +1424,13 @@ void Audio::processLocalFile() {
                 if(audio_info) audio_info(chbuf);
                 setFilePos(m_loop_point);
                 InBuff.resetBuffer();
+                /*
+                    The current time of the loop mode is not reset, 
+                    which will cause the total audio duration to be exceeded.
+                    For example: current time   ====progress bar====>  total audio duration
+                                    3:43        ====================>        3:33
+                */
+                m_audioCurrentTime = 0;
                 return;
             }
             //TEST loop


### PR DESCRIPTION
Yesterday when I was debugging the MP3 single loop playback function, I found that after setting Audio::setFileLoop(true), the song was played and jumped to the beginning, the current audio time was not reset, and the time continued to increase, resulting in exceeding the total audio duration.