### PR TITLE
Added support for floating point duration

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2937,6 +2937,18 @@ uint32_t Audio::getAudioFileDuration() {
     else return 0;
     return m_audioFileDuration;
 }
+float Audio::getAudioFileDurationFloat() {
+    if(m_f_localfile) {if(!audiofile) return 0.0;}
+    if(m_f_webfile)   {if(!m_contentlength) return 0.0;}
+
+    if(!m_avr_bitrate) return 0.0;
+    if     (m_codec == CODEC_MP3) return 8.0 * (float)m_audioDataSize / (float)m_avr_bitrate;
+    else if(m_codec == CODEC_WAV) return 8.0 * (float)m_audioDataSize / (float)m_avr_bitrate;
+    else if(m_codec == CODEC_M4A) return 8.0 * (float)m_audioDataSize / (float)m_avr_bitrate;
+    else if(m_codec == CODEC_AAC) return 8.0 * (float)m_audioDataSize / (float)m_avr_bitrate;
+    else return 0.0;
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 uint32_t Audio::getAudioCurrentTime() {  // return current time in seconds
     if(m_codec == CODEC_FLAC) return 0;

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -121,6 +121,7 @@ public:
      * @return uint32_t file duration in seconds, 0 if no file active
      */
     uint32_t getAudioFileDuration();
+    float getAudioFileDurationFloat();
     /**
      * @brief Get the current plying time in seconds
      * 


### PR DESCRIPTION
This is a follow-up to a previously closed request. Instead of using ms, it returns the seconds as a float. I think this carries fewer implications regarding the fidelity of the data, while still allowing sub-second resolution on the duration if needed. I'm definitely open to other ideas though if something like this is still an issue. 