### PR TITLE
Calculate power levels during playback for visualization

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -1926,8 +1926,8 @@ uint8_t Audio::getPowerLevel() {
 bool Audio::playChunk() {
     // If we've got data, try and pump it out..
     int16_t sample[2];
-    uint8_t max = 0;
-    uint8_t min = 0xFF;
+    uint8_t maxPower = 0;
+    uint8_t minPower = 0xFF;
     if(getBitsPerSample() == 8) {
         if(m_channels == 1) {
             while(m_validSamples) {
@@ -1935,19 +1935,19 @@ bool Audio::playChunk() {
                 uint8_t y = (m_outBuff[m_curSample] & 0xFF00) >> 8;
                 sample[LEFTCHANNEL]  = x;
                 sample[RIGHTCHANNEL] = x;
-                if(sample[LEFTCHANNEL] > max ) max = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] > max ) max = sample[RIGHTCHANNEL];
-                if(sample[LEFTCHANNEL] < min ) min = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] < min ) min = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] > maxPower ) maxPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] > maxPower ) maxPower = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] < minPower ) minPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] < minPower ) minPower = sample[RIGHTCHANNEL];
                 while(1) {
                     if(playSample(sample)) break;
                 } // Can't send?
                 sample[LEFTCHANNEL]  = y;
                 sample[RIGHTCHANNEL] = y;
-                if(sample[LEFTCHANNEL] > max ) max = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] > max ) max = sample[RIGHTCHANNEL];
-                if(sample[LEFTCHANNEL] < min ) min = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] < min ) min = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] > maxPower ) maxPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] > maxPower ) maxPower = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] < minPower ) minPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] < minPower ) minPower = sample[RIGHTCHANNEL];
                 while(1) {
                     if(playSample(sample)) break;
                 } // Can't send?
@@ -1969,10 +1969,10 @@ bool Audio::playChunk() {
                     sample[RIGHTCHANNEL] = xy;
                 }
 
-                if(sample[LEFTCHANNEL] > max ) max = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] > max ) max = sample[RIGHTCHANNEL];
-                if(sample[LEFTCHANNEL] < min ) min = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] < min ) min = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] > maxPower ) maxPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] > maxPower ) maxPower = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] < minPower ) minPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] < minPower ) minPower = sample[RIGHTCHANNEL];
                 while(1) {
                     if(playSample(sample)) break;
                 } // Can't send?
@@ -1980,6 +1980,7 @@ bool Audio::playChunk() {
                 m_curSample++;
             }
         }
+        power = maxPower - minPower;
         m_curSample = 0;
         return true;
     }
@@ -1988,10 +1989,10 @@ bool Audio::playChunk() {
             while(m_validSamples) {
                 sample[LEFTCHANNEL]  = m_outBuff[m_curSample];
                 sample[RIGHTCHANNEL] = m_outBuff[m_curSample];
-                if(sample[LEFTCHANNEL] > max ) max = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] > max ) max = sample[RIGHTCHANNEL];
-                if(sample[LEFTCHANNEL] < min ) min = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] < min ) min = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] > maxPower ) maxPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] > maxPower ) maxPower = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] < minPower ) minPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] < minPower ) minPower = sample[RIGHTCHANNEL];
                 if(!playSample(sample)) {
                     return false;
                 } // Can't send
@@ -2010,10 +2011,10 @@ bool Audio::playChunk() {
                     sample[LEFTCHANNEL] = xy;
                     sample[RIGHTCHANNEL] = xy;
                 }
-                if(sample[LEFTCHANNEL] > max ) max = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] > max ) max = sample[RIGHTCHANNEL];
-                if(sample[LEFTCHANNEL] < min ) min = sample[LEFTCHANNEL];
-                if(sample[RIGHTCHANNEL] < min ) min = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] > maxPower ) maxPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] > maxPower ) maxPower = sample[RIGHTCHANNEL];
+                if(sample[LEFTCHANNEL] < minPower ) minPower = sample[LEFTCHANNEL];
+                if(sample[RIGHTCHANNEL] < minPower ) minPower = sample[RIGHTCHANNEL];
                 if(!playSample(sample)) {
                     return false;
                 } // Can't send
@@ -2021,7 +2022,7 @@ bool Audio::playChunk() {
                 m_curSample++;
             }
         }
-        power = max - min;
+        power = maxPower - minPower;
         m_curSample = 0;
         return true;
     }

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -122,6 +122,7 @@ public:
     uint32_t getWritePos();                     // write position relative to the beginning
     uint32_t getReadPos();                      // read position relative to the beginning
     void     resetBuffer();                     // restore defaults
+    
 
 protected:
     const size_t m_buffSizePSRAM    = 300000; // most webstreams limit the advance to 100...300Kbytes
@@ -161,6 +162,7 @@ public:
     bool pauseResume();
     bool isRunning() {return m_f_running;}
     void loop();
+    uint8_t getPowerLevel();
     void stopSong();
     void forceMono(bool m);
     void setBalance(int8_t bal = 0);
@@ -380,6 +382,7 @@ private:
     int8_t          m_gain0 = 0;                    // cut or boost filters (EQ)
     int8_t          m_gain1 = 0;
     int8_t          m_gain2 = 0;
+    uint8_t          power = 0;
 };
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
During playback the powerlevel is now calculated and made available with the method 
`uint8_t getPowerLevel()`

further processing then can happen my code.


referencing https://github.com/schreibfaul1/ESP32-audioI2S/issues/169