### PR TITLE
simplify http / https handling

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -15,6 +15,7 @@
 fs::SDFATFS SD_SDFAT;
 #endif
 
+
 //---------------------------------------------------------------------------------------------------------------------
 AudioBuffer::AudioBuffer(size_t maxBlockSize) {
     // if maxBlockSize isn't set use defaultspace (1600 bytes) is enough for aac and mp3 player
@@ -513,7 +514,7 @@ bool Audio::connecttohost(const char* host, const char* user, const char* pwd) {
     const uint32_t TIMEOUT_MS_SSL{2700};
     uint32_t t = millis();
     if(_client->connect(hostwoext, port, m_f_ssl ? TIMEOUT_MS_SSL : TIMEOUT_MS)) {
-//      clientsecure.setNoDelay(true);
+        _client->setNoDelay(true);
         // if(audio_info) audio_info("SSL/TLS Connected to server");
         _client->print(resp);
         uint32_t dt = millis() - t;

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -232,7 +232,7 @@ private:
     int16_t* IIR_filterChain2(int16_t* iir_in, bool clear = false);
     inline void setDatamode(uint8_t dm){m_datamode=dm;}
     inline uint8_t getDatamode(){return m_datamode;}
-    inline uint32_t streamavail() {if(m_f_ssl==false) return client.available(); else return clientsecure.available();}
+    inline uint32_t streamavail(){ return _client ? _client->available() : 0;}
     void IIR_calculateCoefficients(int8_t G1, int8_t G2, int8_t G3);
 
     // implement several function with respect to the index of string
@@ -390,6 +390,7 @@ private:
     File              audiofile;    // @suppress("Abstract class cannot be instantiated")
     WiFiClient        client;       // @suppress("Abstract class cannot be instantiated")
     WiFiClientSecure  clientsecure; // @suppress("Abstract class cannot be instantiated")
+    WiFiClient*       _client = nullptr;
     WiFiUDP           udpclient;    // @suppress("Abstract class cannot be instantiated")
     i2s_config_t      m_i2s_config; // stores values for I2S driver
     i2s_pin_config_t  m_pin_config;


### PR DESCRIPTION
instead of duplicating code for both WiFiClient and WiFiClientSecure,
use one pointer that gets assigned the corresponding class.