### PR TITLE
Buffersize configurable

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -57,6 +57,7 @@ size_t AudioBuffer::init() {
     }
     if(!m_buffer)
         return 0;
+    m_f_init = true;
     resetBuffer();
     return m_buffSize;
 }
@@ -205,17 +206,15 @@ Audio::Audio(bool internalDAC /* = false */, i2s_dac_mode_t channelEnabled /* = 
 }
 //---------------------------------------------------------------------------------------------------------------------
 void Audio::initInBuff() {
-    if(!m_f_initInbuffOnce) {
+    if(!InBuff.isInitialized()) {
         size_t size = InBuff.init();
         if(size == m_buffSizeRAM - m_resBuffSizeRAM) {
             AUDIO_INFO(sprintf(chbuf, "PSRAM not found, inputBufferSize: %u bytes", size - 1);)
             m_f_psram = false;
-            m_f_initInbuffOnce = true;
         }
         if(size == m_buffSizePSRAM - m_resBuffSizePSRAM) {
             AUDIO_INFO(sprintf(chbuf, "PSRAM found, inputBufferSize: %u bytes", size - 1);)
             m_f_psram = true;
-            m_f_initInbuffOnce = true;
         }
     }
     changeMaxBlockSize(1600); // default size mp3 or aac
@@ -258,7 +257,6 @@ esp_err_t Audio::i2s_mclk_pin_select(const uint8_t pin) {
 Audio::~Audio() {
     //I2Sstop(m_i2s_num);
     //InBuff.~AudioBuffer(); #215 the AudioBuffer is automatically destroyed by the destructor
-    m_f_initInbuffOnce = false;
     setDefaults();
     if(m_playlistBuff) {free(m_playlistBuff); m_playlistBuff = NULL;}
     i2s_driver_uninstall((i2s_port_t)m_i2s_num); // #215 free I2S buffer

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -35,22 +35,26 @@ AudioBuffer::~AudioBuffer() {
     m_buffer = NULL;
 }
 
+void AudioBuffer::setBufsize(int ram, int psram) {
+    if (ram > -1) // -1 == default / no change
+        m_buffSizeRAM = ram;
+    if (psram > -1)
+        m_buffSizePSRAM = psram;
+}
+
 size_t AudioBuffer::init() {
     if(m_buffer) free(m_buffer);
     m_buffer = NULL;
-    if(psramInit()) {
+    if(psramInit() && m_buffSizePSRAM > 0) {
         // PSRAM found, AudioBuffer will be allocated in PSRAM
+        m_f_psram = true;
         m_buffSize = m_buffSizePSRAM;
-        if(m_buffer == NULL) {
-            m_buffer = (uint8_t*) ps_calloc(m_buffSize, sizeof(uint8_t));
-            m_buffSize = m_buffSizePSRAM - m_resBuffSizePSRAM;
-            if(m_buffer == NULL) {
-                // not enough space in PSRAM, use ESP32 Flash Memory instead
-                m_buffer = (uint8_t*) calloc(m_buffSize, sizeof(uint8_t));
-                m_buffSize = m_buffSizeRAM - m_resBuffSizeRAM;
-            }
-        }
-    } else {  // no PSRAM available, use ESP32 Flash Memory"
+        m_buffer = (uint8_t*) ps_calloc(m_buffSize, sizeof(uint8_t));
+        m_buffSize = m_buffSizePSRAM - m_resBuffSizePSRAM;
+    }
+    if(m_buffer == NULL) {
+        // PSRAM not found, not configured or not enough available
+        m_f_psram = false;
         m_buffSize = m_buffSizeRAM;
         m_buffer = (uint8_t*) calloc(m_buffSize, sizeof(uint8_t));
         m_buffSize = m_buffSizeRAM - m_resBuffSizeRAM;
@@ -205,20 +209,24 @@ Audio::Audio(bool internalDAC /* = false */, i2s_dac_mode_t channelEnabled /* = 
     }
 }
 //---------------------------------------------------------------------------------------------------------------------
+void Audio::setBufsize(int rambuf_sz, int psrambuf_sz) {
+    if(InBuff.isInitialized()) {
+        ESP_LOGE(TAG, "Audio::setBufsize must not be called after audio is initialized");
+        return;
+    }
+    InBuff.setBufsize(rambuf_sz, psrambuf_sz);
+};
+
 void Audio::initInBuff() {
     if(!InBuff.isInitialized()) {
         size_t size = InBuff.init();
-        if(size == m_buffSizeRAM - m_resBuffSizeRAM) {
-            AUDIO_INFO(sprintf(chbuf, "PSRAM not found, inputBufferSize: %u bytes", size - 1);)
-            m_f_psram = false;
-        }
-        if(size == m_buffSizePSRAM - m_resBuffSizePSRAM) {
-            AUDIO_INFO(sprintf(chbuf, "PSRAM found, inputBufferSize: %u bytes", size - 1);)
-            m_f_psram = true;
+        if (size > 0) {
+            AUDIO_INFO(sprintf(chbuf, "PSRAM %sfound, inputBufferSize: %u bytes", InBuff.havePSRAM()?"":"not ", size - 1);)
         }
     }
     changeMaxBlockSize(1600); // default size mp3 or aac
 }
+
 //---------------------------------------------------------------------------------------------------------------------
 esp_err_t Audio::I2Sstart(uint8_t i2s_num) {
     // It is not necessary to call this function after i2s_driver_install() (it is started automatically),
@@ -3043,7 +3051,7 @@ void Audio::processWebStream() {
 
         int16_t bytesAddedToBuffer = 0;
 
-        if(m_f_psram) if(bytesCanBeWritten > 4096) bytesCanBeWritten = 4096; // PSRAM throttle
+        if(InBuff.havePSRAM()) if(bytesCanBeWritten > 4096) bytesCanBeWritten = 4096; // PSRAM throttle
 
         if(m_f_webfile){
             // normally there is nothing to do here, if byteCounter == contentLength

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -130,22 +130,22 @@ public:
     bool     havePSRAM() { return m_f_psram; };
 
 protected:
-    size_t       m_buffSizePSRAM    = 300000;   // most webstreams limit the advance to 100...300Kbytes
-    size_t       m_buffSizeRAM      = 1600 * 5;
-    size_t       m_buffSize         = 0;
-    size_t       m_freeSpace        = 0;
-    size_t       m_writeSpace       = 0;
-    size_t       m_dataLength       = 0;
-    size_t       m_resBuffSizeRAM   = 1600;     // reserved buffspace, >= one mp3  frame
-    size_t       m_resBuffSizePSRAM = 4096 * 4; // reserved buffspace, >= one flac frame
-    size_t       m_maxBlockSize     = 1600;
-    uint8_t*     m_buffer           = NULL;
-    uint8_t*     m_writePtr         = NULL;
-    uint8_t*     m_readPtr          = NULL;
-    uint8_t*     m_endPtr           = NULL;
-    bool         m_f_start          = true;
-    bool         m_f_init           = false;
-    bool         m_f_psram          = false;    // PSRAM is available (and used...)
+    size_t   m_buffSizePSRAM    = 300000;   // most webstreams limit the advance to 100...300Kbytes
+    size_t   m_buffSizeRAM      = 1600 * 5;
+    size_t   m_buffSize         = 0;
+    size_t   m_freeSpace        = 0;
+    size_t   m_writeSpace       = 0;
+    size_t   m_dataLength       = 0;
+    size_t   m_resBuffSizeRAM   = 1600;     // reserved buffspace, >= one mp3  frame
+    size_t   m_resBuffSizePSRAM = 4096 * 4; // reserved buffspace, >= one flac frame
+    size_t   m_maxBlockSize     = 1600;
+    uint8_t* m_buffer           = NULL;
+    uint8_t* m_writePtr         = NULL;
+    uint8_t* m_readPtr          = NULL;
+    uint8_t* m_endPtr           = NULL;
+    bool     m_f_start          = true;
+    bool     m_f_init           = false;
+    bool     m_f_psram          = false;    // PSRAM is available (and used...)
 };
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -114,6 +114,7 @@ public:
     ~AudioBuffer();                             // frees the buffer
     size_t   init();                            // set default values
     bool     isInitialized() { return m_f_init; };
+    void     setBufsize(int ram, int psram);
     void     changeMaxBlockSize(uint16_t mbs);  // is default 1600 for mp3 and aac, set 16384 for FLAC
     uint16_t getMaxBlockSize();                 // returns maxBlockSize
     size_t   freeSpace();                       // number of free bytes to overwrite
@@ -126,10 +127,11 @@ public:
     uint32_t getWritePos();                     // write position relative to the beginning
     uint32_t getReadPos();                      // read position relative to the beginning
     void     resetBuffer();                     // restore defaults
+    bool     havePSRAM() { return m_f_psram; };
 
 protected:
-    const size_t m_buffSizePSRAM    = 300000; // most webstreams limit the advance to 100...300Kbytes
-    const size_t m_buffSizeRAM      = 1600 * 5;
+    size_t       m_buffSizePSRAM    = 300000;   // most webstreams limit the advance to 100...300Kbytes
+    size_t       m_buffSizeRAM      = 1600 * 5;
     size_t       m_buffSize         = 0;
     size_t       m_freeSpace        = 0;
     size_t       m_writeSpace       = 0;
@@ -143,6 +145,7 @@ protected:
     uint8_t*     m_endPtr           = NULL;
     bool         m_f_start          = true;
     bool         m_f_init           = false;
+    bool         m_f_psram          = false;    // PSRAM is available (and used...)
 };
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -153,6 +156,7 @@ class Audio : private AudioBuffer{
 public:
     Audio(bool internalDAC = false, i2s_dac_mode_t channelEnabled = I2S_DAC_CHANNEL_LEFT_EN); // #99
     ~Audio();
+    void setBufsize(int rambuf_sz, int psrambuf_sz);
     bool connecttohost(const char* host, const char* user = "", const char* pwd = "");
     bool connecttospeech(const char* speech, const char* lang);
     bool connecttoFS(fs::FS &fs, const char* path);
@@ -454,7 +458,6 @@ private:
     bool            m_f_playing = false;            // valid mp3 stream recognized
     bool            m_f_webfile = false;            // assume it's a radiostream, not a podcast
     bool            m_f_tts = false;                // text to speech
-    bool            m_f_psram = false;              // set if PSRAM is availabe
     bool            m_f_loop = false;               // Set if audio file should loop
     bool            m_f_forceMono = false;          // if true stereo -> mono
     bool            m_f_internalDAC = false;        // false: output vis I2S, true output via internal DAC

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -113,6 +113,7 @@ public:
     AudioBuffer(size_t maxBlockSize = 0);       // constructor
     ~AudioBuffer();                             // frees the buffer
     size_t   init();                            // set default values
+    bool     isInitialized() { return m_f_init; };
     void     changeMaxBlockSize(uint16_t mbs);  // is default 1600 for mp3 and aac, set 16384 for FLAC
     uint16_t getMaxBlockSize();                 // returns maxBlockSize
     size_t   freeSpace();                       // number of free bytes to overwrite
@@ -141,6 +142,7 @@ protected:
     uint8_t*     m_readPtr          = NULL;
     uint8_t*     m_endPtr           = NULL;
     bool         m_f_start          = true;
+    bool         m_f_init           = false;
 };
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -460,7 +462,6 @@ private:
     bool            m_f_m3u8data = false;           // used in processM3U8entries
     bool            m_f_Log = true;                 // if m3u8: log is cancelled
     bool            m_f_continue = false;           // next m3u8 chunk is available
-    bool            m_f_initInbuffOnce = false;     // init InBuff only once
     i2s_dac_mode_t  m_f_channelEnabled = I2S_DAC_CHANNEL_LEFT_EN;  // internal DAC on GPIO26 for M5StickC/Plus
     uint32_t        m_audioFileDuration = 0;
     float           m_audioCurrentTime = 0;


### PR DESCRIPTION
Make the buffer size of both RAM and PSRAM buffer configurable at run time.
Setting PSRAM to "0" will disable PSRAM usage, even if it is available.

There are a few style changes in the AudioBuffer class also: instead of keeping track in the caller if the buffer has been initialized, just put that knowledge into the AudioBuffer class.Also move the "PSRAM is used" flag into the buffer class, so that no complicated comparison of buffer sizes is necessary to find out if it is the case or not.

WHY would one want to *not* use PSRAM if available? I have the case right now, that my WiFi connection gets bad from time to time (buffer emptying, pings increasing into the 10 seconds range, ...) on my setup (ESP32-A1S with ES8388 plus SPI OLED display), and disabling PSRAM usage seems to work around that. Together with a 32k RAM buffer this is a temporary "fix" until I identified the real issue.