### PR TITLE
add getCodec() and getCodecname() functions

### DIFF
--- a/src/Audio.h
+++ b/src/Audio.h
@@ -193,6 +193,10 @@ public:
     void setTone(int8_t gainLowPass, int8_t gainBandPass, int8_t gainHighPass);
     [[deprecated]]void setInternalDAC(bool internalDAC = true, i2s_dac_mode_t channelEnabled = I2S_DAC_CHANNEL_LEFT_EN);
     void setI2SCommFMT_LSB(bool commFMT);
+    int getCodec() {return m_codec;}
+    const char *getCodecname() {return codecname[m_codec];}
+    enum : int { CODEC_NONE, CODEC_WAV, CODEC_MP3, CODEC_AAC, CODEC_M4A, CODEC_FLAC, CODEC_OGG,
+                 CODEC_OGG_FLAC, CODEC_OGG_OPUS};
 
 private:
     void UTF8toASCII(char* str);
@@ -365,12 +369,10 @@ private:
         return expectedLen;
     }
 
-
 private:
+    const char *codecname[9] = {"unknown", "WAV", "MP3", "AAC", "M4A", "FLAC", "OGG", "OGG FLAC", "OPUS"};
     enum : int { APLL_AUTO = -1, APLL_ENABLE = 1, APLL_DISABLE = 0 };
     enum : int { EXTERNAL_I2S = 0, INTERNAL_DAC = 1, INTERNAL_PDM = 2 };
-    enum : int { CODEC_NONE, CODEC_WAV, CODEC_MP3, CODEC_AAC, CODEC_M4A, CODEC_FLAC, CODEC_OGG,
-                 CODEC_OGG_FLAC, CODEC_OGG_OPUS};
     enum : int { FORMAT_NONE = 0, FORMAT_M3U = 1, FORMAT_PLS = 2, FORMAT_ASX = 3, FORMAT_M3U8 = 4};
     enum : int { AUDIO_NONE, AUDIO_HEADER, AUDIO_DATA,
                  AUDIO_PLAYLISTINIT, AUDIO_PLAYLISTHEADER,  AUDIO_PLAYLISTDATA};


### PR DESCRIPTION
getCodecname() allows for simple display of the used codec,
getCodec() together with the exported enum of codec values allows for
user defined codec names like this stupid example:
  switch (audio.getCodec()) {
    case Audio::CODEC_M4A:
    case Audio::CODEC_AAC:
      Serial.println("AAC codec!");
      break;
    case Audio::CODEC_FLAC:
    case AUDIO::CODEC_OGG_FLAC:
      Serial.println("FLAC!");
      break;
  }