### PR TITLE
getBitRate: add option for average bitrate

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -3978,7 +3978,9 @@ bool Audio::setBitrate(int br){
     if(br)return true;
     return false;
 }
-uint32_t Audio::getBitRate(){
+uint32_t Audio::getBitRate(bool avg){
+    if (avg)
+        return m_avr_bitrate;
     return m_bitRate;
 }
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -182,7 +182,7 @@ public:
     uint32_t getSampleRate();
     uint8_t  getBitsPerSample();
     uint8_t  getChannels();
-    uint32_t getBitRate();
+    uint32_t getBitRate(bool avg = false);
     uint32_t getAudioFileDuration();
     uint32_t getAudioCurrentTime();
     uint32_t getTotalPlayingTime();


### PR DESCRIPTION
average bitrate is sometimes useful for display in a UI with e.g. AAC codec