### PR TITLE
event audio_process_i2s for processing audio data extern after applyi…

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -4371,6 +4371,15 @@ bool Audio::playSample(int16_t sample[2]) {
 
     uint32_t s32 = Gain(sample); // vosample2lume;
 
+    if(audio_process_i2s){
+		// process audio sample just before writing to i2s
+        bool continueI2S = false;
+        audio_process_i2s(&s32, &continueI2S);
+        if(!continueI2S){
+            return true;
+        }
+    }
+
     if(m_f_internalDAC) {
         s32 += 0x80008000;
     }

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -82,6 +82,7 @@ extern __attribute__((weak)) void audio_lasthost(const char*);
 extern __attribute__((weak)) void audio_eof_speech(const char*);
 extern __attribute__((weak)) void audio_eof_stream(const char*); // The webstream comes to an end
 extern __attribute__((weak)) void audio_process_extern(int16_t* buff, uint16_t len, bool *continueI2S); // record audiodata or send via BT
+extern __attribute__((weak)) void audio_process_i2s(uint32_t* sample, bool *continueI2S); // record audiodata or send via BT
 
 #define AUDIO_INFO(...) {char buff[512 + 64]; sprintf(buff,__VA_ARGS__); if(audio_info) audio_info(buff);}
 


### PR DESCRIPTION
Hi Wolle,

i have created a feature for ESPuino, sending audio through A2DP-source to a bluetooth headset.
Please provide an event to process audio data extern, just before writing to i2s but after applying all filtering and gain.
`audio_process_extern` is too early, channel, BitsPerSample, filter and gain are not applied and i have to process the same things your already do.

With this PR changes i can transmit audio to BT-headset successfully! The only restriction is that sampling-rate has to be 44.1KHZ. Maybe later a resampling filter can be added.

Thanks and best
Dirk