### PR TITLE
Allow to customize the number of volume steps

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -50,8 +50,7 @@ size_t AudioBuffer::init() {
     if(m_buffer == NULL) {
         // PSRAM not found, not configured or not enough available
         m_f_psram = false;
-        m_buffSize = m_buffSizeRAM;
-        m_buffer = (uint8_t*) calloc(m_buffSize, sizeof(uint8_t));
+        m_buffer = (uint8_t*) heap_caps_malloc(m_buffSizeRAM, MALLOC_CAP_DEFAULT|MALLOC_CAP_INTERNAL);
         m_buffSize = m_buffSizeRAM - m_resBuffSizeRAM;
     }
     if(!m_buffer)

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -4199,12 +4199,36 @@ void Audio::setBalance(int8_t bal){ // bal -16...16
     m_balance = bal;
 }
 //---------------------------------------------------------------------------------------------------------------------
+void Audio::setVolumeSteps(uint8_t steps) {
+    m_vol_steps = steps;
+    if (steps < 1)
+        m_vol_step_div = 64; /* avoid div-by-zero :-) */
+    else
+        m_vol_step_div = steps * steps;
+    log_i("m_vol_step_div: %d", m_vol_step_div);
+}
+//---------------------------------------------------------------------------------------------------------------------
+uint8_t Audio::maxVolume() {
+    if (m_vol_steps)
+        return m_vol_steps;
+    return 21;
+};
+//---------------------------------------------------------------------------------------------------------------------
 void Audio::setVolume(uint8_t vol) { // vol 22 steps, 0...21
+    if (m_vol_steps) {
+        if (vol > m_vol_steps) vol = m_vol_steps;
+        m_vol = vol * vol;
+        return;
+    }
     if(vol > 21) vol = 21;
     m_vol = volumetable[vol];
 }
 //---------------------------------------------------------------------------------------------------------------------
 uint8_t Audio::getVolume() {
+    if (m_vol_steps) {
+        uint8_t vol = sqrt(m_vol);
+        return vol;
+    }
     for(uint8_t i = 0; i < 22; i++) {
         if(volumetable[i] == m_vol) return i;
     }
@@ -4218,20 +4242,18 @@ uint8_t Audio::getI2sPort() {
 //---------------------------------------------------------------------------------------------------------------------
 int32_t Audio::Gain(int16_t s[2]) {
     int32_t v[2];
-    float step = (float)m_vol /64;
-    uint8_t l = 0, r = 0;
+    int32_t l = m_vol, r = m_vol;
 
+    /* balance is left -16...+16 right */
+    /* TODO: logarithmic scaling of balance, too? */
     if(m_balance < 0){
-        step = step * (float)(abs(m_balance) * 4);
-        l = (uint8_t)(step);
+        r -= (int32_t)m_vol * abs(m_balance) / 16;
+    } else if(m_balance > 0){
+        l -= (int32_t)m_vol * abs(m_balance) / 16;
     }
-    if(m_balance > 0){
-        step = step * m_balance * 4;
-        r = (uint8_t)(step);
-    }
-
-    v[LEFTCHANNEL] = (s[LEFTCHANNEL]  * (m_vol - l)) >> 6;
-    v[RIGHTCHANNEL]= (s[RIGHTCHANNEL] * (m_vol - r)) >> 6;
+    /* important: these multiplications must all be signed ints, or the result will be invalid */
+    v[LEFTCHANNEL] = (s[LEFTCHANNEL]  * l) / m_vol_step_div;
+    v[RIGHTCHANNEL]= (s[RIGHTCHANNEL] * r) / m_vol_step_div;
 
     return (v[LEFTCHANNEL] << 16) | (v[RIGHTCHANNEL] & 0xffff);
 }

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -182,8 +182,10 @@ public:
     uint32_t stopSong();
     void forceMono(bool m);
     void setBalance(int8_t bal = 0);
+    void setVolumeSteps(uint8_t steps);
     void setVolume(uint8_t vol);
     uint8_t getVolume();
+    uint8_t maxVolume();
     uint8_t getI2sPort();
 
     uint32_t getAudioDataStartPos();
@@ -491,7 +493,9 @@ private:
     uint32_t        m_metacount = 0;                // counts down bytes between metadata
     int             m_controlCounter = 0;           // Status within readID3data() and readWaveHeader()
     int8_t          m_balance = 0;                  // -16 (mute left) ... +16 (mute right)
-    uint8_t         m_vol=64;                       // volume
+    uint16_t        m_vol=64;                       // volume
+    uint8_t         m_vol_steps = 0;                // 0 == legacy 21 steps, > 0: number of volume steps
+    int32_t         m_vol_step_div = 64;            // max of volumetable[]
     uint8_t         m_bitsPerSample = 16;           // bitsPerSample
     uint8_t         m_channels = 2;
     uint8_t         m_i2s_num = I2S_NUM_0;          // I2S_NUM_0 or I2S_NUM_1


### PR DESCRIPTION
Instead of hard coded 21 steps, allow to customize the number of steps.
No change by default if the "setVolumeSteps()" method is not called.

The PSRAM commit is just a fixup of the earlier "allow to disable PSRAM usage" feature. The allocater could decide to use PSRAM for bigger buffers, even if not explicitly instructed to do so.