### PR TITLE
prevent background task to get all CPU

### DIFF
--- a/examples/separate_audiotask/separate_audiotask.ino
+++ b/examples/separate_audiotask/separate_audiotask.ino
@@ -74,6 +74,9 @@ void audioTask(void *parameter) {
             }
         }
         audio.loop();
+        if (!audio.isRunning()) {
+          sleep(1);
+        }
     }
 }
 


### PR DESCRIPTION
This is a fix proposal to avoid that the high priority of the separate background task will get almost all CPU and the sketch loop() function is not called. This happens when no audio is running as the audio.loop will return fast and called again on high priority. When there is playing audio the separate task gets suspended while waiting for network packages,