### PR TITLE
Provide audio_id3lyrics() callback

### DIFF
--- a/src/Audio.h
+++ b/src/Audio.h
@@ -73,6 +73,7 @@ using namespace std;
 extern __attribute__((weak)) void audio_info(const char*);
 extern __attribute__((weak)) void audio_id3data(const char*); //ID3 metadata
 extern __attribute__((weak)) void audio_id3image(File& file, const size_t pos, const size_t size); //ID3 metadata image
+extern __attribute__((weak)) void audio_id3lyrics(File& file, const size_t pos, const size_t size); //ID3 metadata lyrics
 extern __attribute__((weak)) void audio_eof_mp3(const char*); //end of mp3 file
 extern __attribute__((weak)) void audio_showstreamtitle(const char*);
 extern __attribute__((weak)) void audio_showstation(const char*);
@@ -207,6 +208,7 @@ public:
     void setI2SCommFMT_LSB(bool commFMT);
     int getCodec() {return m_codec;}
     const char *getCodecname() {return codecname[m_codec];}
+    void unicode2utf8(char* buff, uint32_t len);
 
 private:
 
@@ -240,7 +242,6 @@ private:
     void compute_audioCurrentTime(int bd);
     void printDecodeError(int r);
     void showID3Tag(const char* tag, const char* val);
-    void unicode2utf8(char* buff, uint32_t len);
     size_t readAudioHeader(uint32_t bytes);
     int  read_WAV_Header(uint8_t* data, size_t len);
     int  read_FLAC_Header(uint8_t *data, size_t len);


### PR DESCRIPTION
Since the lyrics text is larger than 512 byte frame size in most case, it is better provide a audio_id3lyrics() callback similar to the audio_id3image(). 