### PR TITLE
Support for building as an IDF 4.4.4 component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+get_filename_component(dir ${CMAKE_CURRENT_LIST_FILE} PATH)
+FILE(GLOB_RECURSE app_sources ${dir}/src/*.cpp)
+
+idf_component_register(SRCS ${app_sources}      
+                    REQUIRES "ESP32-audioI2S"
+                    INCLUDE_DIRS "src"
+                    REQUIRES wear_levelling Arduino
+)


### PR DESCRIPTION
Why IDF 4.4.4? Because IDF 4.4.5 wouldn't compile with arduino-esp32. And IDF5+ definitely won't yet (someday!).