### PR TITLE
avoid flush() after stop() on WiFiClient

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -334,9 +334,7 @@ void Audio::setDefaults() {
     vector_clear_and_shrink(m_playlistContent);
     m_hashQueue.clear(); m_hashQueue.shrink_to_fit(); // uint32_t vector
     client.stop();
-    client.flush(); // release memory
     clientsecure.stop();
-    clientsecure.flush();
     _client = static_cast<WiFiClient*>(&client); /* default to *something* so that no NULL deref can happen */
     ts_parsePacket(0, 0, 0); // reset ts routine
 


### PR DESCRIPTION

avoid flush() after stop() on WiFiClient

There is a nullptr access in WiFiClient.

In audio.cpp you find the sequence client.stop() and client.flush();
This creates an unhandled nullptr exception (Guru Meditation Error...)

* `client.stop()` sets `_rxBuffer = NULL;`
* `client.flush()` acts on this buffer without prior nullptr checks: `_rxBuffer->flush();`

Therefore flush() must not be called after stop();

This is definitive a problem with the WiFiClient implementation
but currently stops using the audioI2S library and can be simply avoided.
