### PR TITLE
Fix pausing webstream

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2109,7 +2109,7 @@ uint32_t Audio::stopSong() {
 bool Audio::pauseResume() {
     xSemaphoreTake(mutex_audio, portMAX_DELAY);
     bool retVal = false;
-    if(getDatamode() == AUDIO_LOCALFILE || m_streamType == ST_WEBSTREAM) {
+    if(getDatamode() == AUDIO_LOCALFILE || m_streamType == ST_WEBSTREAM || m_streamType == ST_WEBFILE) {
         m_f_running = !m_f_running;
         retVal = true;
         if(!m_f_running) {


### PR DESCRIPTION
This is a re-request of https://github.com/schreibfaul1/ESP32-audioI2S/issues/449

It got merged into esphome's fork: https://github.com/esphome/ESP32-audioI2S/pull/7 (because of https://github.com/esphome/issues/issues/4447)

I'm not having this issue myself, I just wanted to upstream the (little) changes from esphome's fork of this library, so they can do away with their own fork.