### PR TITLE
Improve duration and currentTime calculation

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -4541,10 +4541,10 @@ uint32_t Audio::getAudioFileDuration() {
         if(!m_contentlength) return 0;
     }
 
-    if(m_avr_bitrate && m_codec == CODEC_MP3) m_audioFileDuration = 8 * (m_audioDataSize / m_avr_bitrate); // #289
-    else if(m_avr_bitrate && m_codec == CODEC_WAV) m_audioFileDuration = 8 * (m_audioDataSize / m_avr_bitrate);
-    else if(m_avr_bitrate && m_codec == CODEC_M4A) m_audioFileDuration = 8 * (m_audioDataSize / m_avr_bitrate);
-    else if(m_avr_bitrate && m_codec == CODEC_AAC) m_audioFileDuration = 8 * (m_audioDataSize / m_avr_bitrate);
+    if(m_avr_bitrate && m_codec == CODEC_MP3) m_audioFileDuration = 8 * ((float)m_audioDataSize / m_avr_bitrate); // #289
+    else if(m_avr_bitrate && m_codec == CODEC_WAV) m_audioFileDuration = 8 * ((float)m_audioDataSize / m_avr_bitrate);
+    else if(m_avr_bitrate && m_codec == CODEC_M4A) m_audioFileDuration = 8 * ((float)m_audioDataSize / m_avr_bitrate);
+    else if(m_avr_bitrate && m_codec == CODEC_AAC) m_audioFileDuration = 8 * ((float)m_audioDataSize / m_avr_bitrate);
     else if(m_codec == CODEC_FLAC) m_audioFileDuration = FLACGetAudioFileDuration();
     else return 0;
     return m_audioFileDuration;

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -352,6 +352,7 @@ void Audio::setDefaults() {
     m_bitRate = 0;         // Bitrate still unknown
     m_bytesNotDecoded = 0; // counts all not decodable bytes
     m_chunkcount = 0;      // for chunked streams
+    m_byteCounter = 0;     // count received data
     m_contentlength = 0;   // If Content-Length is known, count it
     m_curSample = 0;
     m_metaint = 0;        // No metaint yet
@@ -2842,14 +2843,12 @@ void Audio::processLocalFile() {
     const uint32_t  maxFrameSize = InBuff.getMaxBlockSize(); // every mp3/aac frame is not bigger
     static bool     f_stream;
     static bool     f_fileDataComplete;
-    static uint32_t byteCounter; // count received data
     uint32_t        availableBytes = 0;
 
     if(m_f_firstCall) { // runs only one time per connection, prepare for start
         m_f_firstCall = false;
         f_stream = false;
         f_fileDataComplete = false;
-        byteCounter = 0;
         ctime = millis();
         if(m_codec == CODEC_M4A) seek_m4a_stsz(); // determine the pos of atom stsz
         if(m_codec == CODEC_M4A) seek_m4a_ilst(); // looking for metadata
@@ -2859,16 +2858,16 @@ void Audio::processLocalFile() {
     availableBytes = 16 * 1024; // set some large value
 
     availableBytes = min(availableBytes, (uint32_t)InBuff.writeSpace());
-    availableBytes = min(availableBytes, audiofile.size() - byteCounter);
+    availableBytes = min(availableBytes, audiofile.size() - m_byteCounter);
     if(m_contentlength) {
         if(m_contentlength > getFilePos()) availableBytes = min(availableBytes, m_contentlength - getFilePos());
     }
-    if(m_audioDataSize) { availableBytes = min(availableBytes, m_audioDataSize + m_audioDataStart - byteCounter); }
+    if(m_audioDataSize) { availableBytes = min(availableBytes, m_audioDataSize + m_audioDataStart - m_byteCounter); }
 
     int32_t bytesAddedToBuffer = audiofile.read(InBuff.getWritePtr(), availableBytes);
 
     if(bytesAddedToBuffer > 0) {
-        byteCounter += bytesAddedToBuffer; // Pull request #42
+        m_byteCounter += bytesAddedToBuffer; // Pull request #42
         InBuff.bytesWritten(bytesAddedToBuffer);
     }
     if(!f_stream) {
@@ -2904,7 +2903,7 @@ void Audio::processLocalFile() {
             return;
         }
         else {
-            if((InBuff.freeSpace() > maxFrameSize) && (m_file_size - byteCounter) > maxFrameSize && availableBytes) {
+            if((InBuff.freeSpace() > maxFrameSize) && (m_file_size - m_byteCounter) > maxFrameSize && availableBytes) {
                 // fill the buffer before playing
                 return;
             }
@@ -2930,7 +2929,7 @@ void Audio::processLocalFile() {
         if(m_avr_bitrate) m_audioCurrentTime = ((double)(m_resumeFilePos - m_audioDataStart) / m_avr_bitrate) * 8;
         audiofile.seek(m_resumeFilePos);
         InBuff.resetBuffer();
-        byteCounter = m_resumeFilePos;
+        m_byteCounter = m_resumeFilePos;
         f_fileDataComplete = false; // #570
 
         if(m_f_Log) {
@@ -2969,7 +2968,7 @@ void Audio::processLocalFile() {
             setFilePos(m_audioDataStart);
             if(m_codec == CODEC_FLAC) FLACDecoderReset();
             m_audioCurrentTime = 0;
-            byteCounter = m_audioDataStart;
+            m_byteCounter = m_audioDataStart;
             f_fileDataComplete = false;
             return;
         } // loop
@@ -2995,8 +2994,8 @@ void Audio::processLocalFile() {
         return;
     }
 
-    if(byteCounter == audiofile.size()) { f_fileDataComplete = true; }
-    if(byteCounter == m_audioDataSize + m_audioDataStart) { f_fileDataComplete = true; }
+    if(m_byteCounter == audiofile.size()) { f_fileDataComplete = true; }
+    if(m_byteCounter == m_audioDataSize + m_audioDataStart) { f_fileDataComplete = true; }
 
     // play audio data - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     if(f_stream) { playAudioData(); }
@@ -3084,7 +3083,6 @@ void Audio::processWebFile() {
     const uint32_t  maxFrameSize = InBuff.getMaxBlockSize(); // every mp3/aac frame is not bigger
     static bool     f_stream;                                // first audio data received
     static bool     f_webFileDataComplete;                   // all file data received
-    static uint32_t byteCounter;                             // count received data
     static uint32_t chunkSize;                               // chunkcount read from stream
     static size_t   audioDataCount;                          // counts the decoded audiodata only
 
@@ -3094,7 +3092,6 @@ void Audio::processWebFile() {
         m_t0 = millis();
         f_webFileDataComplete = false;
         f_stream = false;
-        byteCounter = 0;
         chunkSize = 0;
         audioDataCount = 0;
     }
@@ -3121,20 +3118,20 @@ void Audio::processWebFile() {
     }
 
     availableBytes = min((uint32_t)InBuff.writeSpace(), availableBytes);
-    availableBytes = min(m_contentlength - byteCounter, availableBytes);
-    if(m_audioDataSize) availableBytes = min(m_audioDataSize - (byteCounter - m_audioDataStart), availableBytes);
+    availableBytes = min(m_contentlength - m_byteCounter, availableBytes);
+    if(m_audioDataSize) availableBytes = min(m_audioDataSize - (m_byteCounter - m_audioDataStart), availableBytes);
 
     int16_t bytesAddedToBuffer = _client->read(InBuff.getWritePtr(), availableBytes);
 
     if(bytesAddedToBuffer > 0) {
-        byteCounter += bytesAddedToBuffer; // Pull request #42
+        m_byteCounter += bytesAddedToBuffer; // Pull request #42
         if(m_f_chunked) m_chunkcount -= bytesAddedToBuffer;
         if(m_controlCounter == 100) audioDataCount += bytesAddedToBuffer;
         InBuff.bytesWritten(bytesAddedToBuffer);
     }
 
     if(!f_stream) {
-        if((InBuff.freeSpace() > maxFrameSize) && (byteCounter < m_contentlength)) return;
+        if((InBuff.freeSpace() > maxFrameSize) && (m_byteCounter < m_contentlength)) return;
         f_stream = true; // ready to play the audio data
         uint16_t filltime = millis() - m_t0;
         AUDIO_INFO("stream ready, buffer filled in %d ms", filltime);
@@ -3207,8 +3204,8 @@ void Audio::processWebFile() {
         return;
     }
 
-    if(byteCounter == m_contentlength) { f_webFileDataComplete = true; }
-    if(byteCounter - m_audioDataStart == m_audioDataSize) { f_webFileDataComplete = true; }
+    if(m_byteCounter == m_contentlength) { f_webFileDataComplete = true; }
+    if(m_byteCounter - m_audioDataStart == m_audioDataSize) { f_webFileDataComplete = true; }
 
     // play audio data - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     if(f_stream) { playAudioData(); }
@@ -3221,7 +3218,6 @@ void Audio::processWebStreamTS() {
     static bool     f_stream;                                // first audio data received
     static bool     f_firstPacket;
     static bool     f_chunkFinished;
-    static uint32_t byteCounter;    // count received data
     static uint8_t  ts_packet[188]; // m3u8 transport stream is 188 bytes long
     uint8_t         ts_packetStart = 0;
     uint8_t         ts_packetLength = 0;
@@ -3234,7 +3230,6 @@ void Audio::processWebStreamTS() {
         f_stream = false;
         f_firstPacket = true;
         f_chunkFinished = false;
-        byteCounter = 0;
         chunkSize = 0;
         m_t0 = millis();
         ts_packetPtr = 0;
@@ -3256,7 +3251,7 @@ void Audio::processWebStreamTS() {
         int res = _client->read(ts_packet + ts_packetPtr, ts_packetsize - ts_packetPtr);
         if(res > 0) {
             ts_packetPtr += res;
-            byteCounter += res;
+            m_byteCounter += res;
             if(ts_packetPtr < ts_packetsize) return;
             ts_packetPtr = 0;
             if(f_firstPacket) { // search for ID3 Header in the first packet
@@ -3288,11 +3283,11 @@ void Audio::processWebStreamTS() {
                     InBuff.bytesWritten(ts_packetLength - ws);
                 }
             }
-            if(byteCounter == m_contentlength || byteCounter == chunkSize) {
+            if (m_byteCounter == m_contentlength || m_byteCounter == chunkSize) {
                 f_chunkFinished = true;
-                byteCounter = 0;
+                m_byteCounter = 0;
             }
-            if(byteCounter > m_contentlength) log_e("byteCounter overflow");
+            if(m_byteCounter > m_contentlength) log_e("m_byteCounter overflow");
         }
     }
     if(f_chunkFinished) {
@@ -3337,7 +3332,6 @@ void Audio::processWebStreamHLS() {
     static bool     f_stream;       // first audio data received
     static bool     firstBytes;
     static bool     f_chunkFinished;
-    static uint32_t byteCounter; // count received data
     static size_t   chunkSize = 0;
     static uint16_t ID3WritePtr;
     static uint16_t ID3ReadPtr;
@@ -3347,7 +3341,6 @@ void Audio::processWebStreamHLS() {
     if(m_f_firstCall) { // runs only ont time per connection, prepare for start
         f_stream = false;
         f_chunkFinished = false;
-        byteCounter = 0;
         chunkSize = 0;
         ID3WritePtr = 0;
         ID3ReadPtr = 0;
@@ -3366,7 +3359,7 @@ void Audio::processWebStreamHLS() {
 
         if(m_f_chunked && !chunkSize) {
             chunkSize = chunkedDataTransfer(&readedBytes);
-            byteCounter += readedBytes;
+            m_byteCounter += readedBytes;
         }
 
         if(firstBytes) {
@@ -3398,7 +3391,7 @@ void Audio::processWebStreamHLS() {
                 InBuff.bytesWritten(ID3BuffSize - (ID3ReadPtr + ws));
             }
             if(ID3Buff) free(ID3Buff);
-            byteCounter += ID3BuffSize;
+            m_byteCounter += ID3BuffSize;
             ID3Buff = NULL;
             firstBytes = false;
         }
@@ -3411,11 +3404,11 @@ void Audio::processWebStreamHLS() {
         else { bytesWasWritten = _client->read(InBuff.getWritePtr(), InBuff.writeSpace()); }
         InBuff.bytesWritten(bytesWasWritten);
 
-        byteCounter += bytesWasWritten;
+        m_byteCounter += bytesWasWritten;
 
-        if(byteCounter == m_contentlength || byteCounter == chunkSize) {
+        if(m_byteCounter == m_contentlength || m_byteCounter == chunkSize) {
             f_chunkFinished = true;
-            byteCounter = 0;
+            m_byteCounter = 0;
         }
     }
 
@@ -4519,12 +4512,18 @@ bool Audio::setPinout(uint8_t BCLK, uint8_t LRC, uint8_t DOUT, int8_t MCLK) {
 }
 //------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 uint32_t Audio::getFileSize() {
-    if(!audiofile) return 0;
+    if(!audiofile) {
+        if (m_contentlength > 0) {
+            return m_contentlength;
+        } else {
+            return 0;
+        }
+    }
     return audiofile.size();
 }
 //------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 uint32_t Audio::getFilePos() {
-    if(!audiofile) return 0;
+    if(!audiofile) return m_byteCounter;
     return audiofile.position();
 }
 //------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -528,6 +528,7 @@ private:
     uint32_t        m_metaint = 0;                  // Number of databytes between metadata
     uint32_t        m_chunkcount = 0 ;              // Counter for chunked transfer
     uint32_t        m_t0 = 0;                       // store millis(), is needed for a small delay
+	uint32_t        m_byteCounter = 0;              // count received data
     uint32_t        m_contentlength = 0;            // Stores the length if the stream comes from fileserver
     uint32_t        m_bytesNotDecoded = 0;          // pictures or something else that comes with the stream
     uint32_t        m_PlayingStartTime = 0;         // Stores the milliseconds after the start of the audio


### PR DESCRIPTION
getAudioFileDuration() uses float calculation to improve accuracy (integer arithmetic causes significant rounding errors).

getFileSize() returns m_content_length for webfiles.

getFilePos() returns the bytesCounter for streams, which fixes m_audioCurrentTime calculation for webfiles.