### PR TITLE
add audio_webfile_start/audio_webfile_data_received/audio_stopped callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ void loop()
 void audio_info(const char *info){
     Serial.print("info        "); Serial.println(info);
 }
+void audio_stopped(const uint32_t pos) {  // called after audio has stopped
+    Serial.print("stopped     "); Serial.println(pos);
+}
 void audio_id3data(const char *info){  //id3 metadata
     Serial.print("id3data     ");Serial.println(info);
 }
@@ -107,6 +110,15 @@ void audio_lasthost(const char *info){  //stream URL played
 void audio_eof_speech(const char *info){
     Serial.print("eof_speech  ");Serial.println(info);
 }
+void audio_eof_stream(const char *lastHost) {  // the webstream comes to an end
+    Serial.print("eof_stream  "); Serial.println(lastHost);
+}
+void audio_webfile_data_received(const uint8_t *writePtr, const int16_t bytesWritten) {  // called after data has been received from a web file stream
+    Serial.print("webfile_data_received "); Serial.print(bytesWritten); Serial.printf(" at %p\n", writePtr); 
+}
+void audio_webfile_start(const bool isTTS, const char *lastHost) {  // the webfile stream starts
+    Serial.print("webfile_start "); Serial.print(isTTS); Serial.print(" "); Serial.println(lastHost);
+};
 
 ````
 Breadboard

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2277,6 +2277,9 @@ uint32_t Audio::stopSong() {
     memset(m_outBuff, 0, m_outbuffSize); // Clear OutputBuffer
     memset(m_filterBuff, 0, sizeof(m_filterBuff)); // Clear FilterBuffer
     m_validSamples = 0;
+    if (audio_stopped) {
+        audio_stopped(pos);
+    }
     return pos;
 }
 //------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -3269,6 +3272,9 @@ void Audio::processWebFile() {
         byteCounter = 0;
         chunkSize = 0;
         audioDataCount = 0;
+        if (audio_webfile_start) {
+            audio_webfile_start(m_f_tts, m_lastHost);
+        }
     }
 
     if(!m_contentlength && !m_f_tts) {
@@ -3296,9 +3302,14 @@ void Audio::processWebFile() {
     availableBytes = min(m_contentlength - byteCounter, availableBytes);
     if(m_audioDataSize) availableBytes = min(m_audioDataSize - (byteCounter - m_audioDataStart), availableBytes);
 
-    int16_t bytesAddedToBuffer = _client->read(InBuff.getWritePtr(), availableBytes);
+    uint8_t *writePtr = InBuff.getWritePtr();
+    int16_t bytesAddedToBuffer = _client->read(writePtr, availableBytes);
 
     if(bytesAddedToBuffer > 0) {
+        if (audio_webfile_data_received) {
+            audio_webfile_data_received(writePtr, bytesAddedToBuffer);
+        }
+
         byteCounter += bytesAddedToBuffer; // Pull request #42
         if(m_f_chunked) m_chunkcount -= bytesAddedToBuffer;
         if(m_controlCounter == 100) audioDataCount += bytesAddedToBuffer;

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -35,6 +35,7 @@
 using namespace std;
 
 extern __attribute__((weak)) void audio_info(const char*);
+extern __attribute__((weak)) void audio_stopped(const uint32_t pos); // called after audio has stopped
 extern __attribute__((weak)) void audio_id3data(const char*); //ID3 metadata
 extern __attribute__((weak)) void audio_id3image(File& file, const size_t pos, const size_t size); //ID3 metadata image
 extern __attribute__((weak)) void audio_oggimage(File& file, std::vector<uint32_t> v); //OGG blockpicture
@@ -50,6 +51,8 @@ extern __attribute__((weak)) void audio_icydescription(const char*);
 extern __attribute__((weak)) void audio_lasthost(const char*);
 extern __attribute__((weak)) void audio_eof_speech(const char*);
 extern __attribute__((weak)) void audio_eof_stream(const char*); // The webstream comes to an end
+extern __attribute__((weak)) void audio_webfile_data_received(const uint8_t *writePtr, const int16_t bytesWritten); // called after data has been received from a web file stream
+extern __attribute__((weak)) void audio_webfile_start(const bool isTTS, const char *lastHost); // the webfile stream starts
 extern __attribute__((weak)) void audio_process_extern(int16_t* buff, uint16_t len, bool *continueI2S); // record audiodata or send via BT
 extern __attribute__((weak)) void audio_process_i2s(uint32_t* sample, bool *continueI2S); // record audiodata or send via BT
 


### PR DESCRIPTION
Adds the following callbacks:
```c
void audio_stopped(const uint32_t pos) // called after audio has stopped
void audio_webfile_data_received(const uint8_t *writePtr, const int16_t bytesWritten) // called after data has been received from a web file stream
void audio_webfile_start(const bool isTTS, const char *lastHost) // the webfile stream starts
```

And adds the existing `audio_eof_stream` callback to the readme