### PR TITLE
Fix noise at first playback by proper filterBuff initialization

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2105,6 +2105,7 @@ uint32_t Audio::stopSong() {
         log_w("Closing audio file"); // for debug
     }
     memset(m_outBuff, 0, 2048 * 2 * sizeof(uint16_t)); // Clear OutputBuffer
+    memset(m_filterBuff, 0, sizeof(m_filterBuff)); // Clear FilterBuffer
     m_validSamples = 0;
     return pos;
 }


### PR DESCRIPTION
This PR will fix issue #626 [Clic-noise for first playback after class initialization](https://github.com/schreibfaul1/ESP32-audioI2S/issues/626#top).