### PR TITLE
improve connecttoFS file opening

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -757,6 +757,9 @@ bool Audio::connecttoFS(fs::FS& fs, const char* path, int32_t resumeFilePos) {
         if (!audioName) {
             AUDIO_INFO("File doesn't exist: \"%s\"", path);
             xSemaphoreGiveRecursive(mutex_audio);
+            if (audioNameAlternative) {
+                free(audioNameAlternative);
+            }
             return false;
         }
 


### PR DESCRIPTION
This PR improves the file opening in `connecttoFS()`.

Instead of always coping the filename to the old stack buffer it now checks for existence of the specified path first and uses the unmodified path if it exists. If it doesn't exist a copy is created in the heap memory (PSRAM preferred) and the existing modifications are applied (leading slash and UTF8toASCII).

That way in the usual cases (correct path given) no extra string copy is required. Additionally this removes the 255 characters length limit for the path.