### PR TITLE
Solution #685 M3U8 noisy

### DIFF
--- a/src/Audio.h
+++ b/src/Audio.h
@@ -530,7 +530,7 @@ private:
     uint32_t        m_metaint = 0;                  // Number of databytes between metadata
     uint32_t        m_chunkcount = 0 ;              // Counter for chunked transfer
     uint32_t        m_t0 = 0;                       // store millis(), is needed for a small delay
-	uint32_t        m_byteCounter = 0;              // count received data
+	//uint32_t        m_byteCounter = 0;              // count received data
     uint32_t        m_contentlength = 0;            // Stores the length if the stream comes from fileserver
     uint32_t        m_bytesNotDecoded = 0;          // pictures or something else that comes with the stream
     uint32_t        m_PlayingStartTime = 0;         // Stores the milliseconds after the start of the audio


### PR DESCRIPTION
Probably the change from local variable to a global one was not totally correct and cause wrong .ts packet finding.
Now the stream:

[http://streamcdnb1-4c4b867c89244861ac216426883d1ad0.msvdn.net/radiodeejay/radiodeejay/play1.m3u8](url)
work fine.
Tested with other stream:

[(http://as-hls-ww-live.akamaized.net/pool_904/live/ww/bbc_6music/bbc_6music.isml/bbc_6music-audio%3d48000.norewind.m3u8](url)
[http://streamcdnf25-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejay80/live.m3u8](url)
[ttp://streamcdnm5-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejayontheroad/live.m3u8](url)
[http://streamcdnm12-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaytropicalpizza/live.m3u8](url)
and they work fine too.
Tested with not m3u8 stream and everything work fine.