### PR TITLE
fix: noisy/distorted audio with internalDAC fixes  #769

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2330,6 +2330,11 @@ void Audio::playChunk(bool i2s_only) {
                 IIR_filterChain2(*sample);
                 //------------------------------------------------------------------
                 Gain(*sample);
+		if(m_f_internalDAC){
+		  s2 = *sample;
+		  s2[LEFTCHANNEL] += 0x8000;
+		  s2[RIGHTCHANNEL]+= 0x8000;
+		}
                 i += 2;
             }
             else{ // 8 bit per sample


### PR DESCRIPTION
since 61fe65b audio on internalDAC was noisy/distorted. It looks like the sign bit (?), necessary when using internalDAC (?) was lost for 16 Bit samples. With this change audio sounds fine again.

Tested with internalDAC.ino.