### PR TITLE
Set task as static

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -6338,13 +6338,14 @@ void Audio::startAudioTask() {
 
     // xTaskCreate(&Audio::taskWrapper, "PeriodicTask", 3300, this, 4, &m_audioTaskHandle);
 
-    xTaskCreatePinnedToCore(
+    xTaskCreateStaticPinnedToCore(
         &Audio::taskWrapper,    /* Function to implement the task */
         "PeriodicTask",         /* Name of the task */
-        3300,                   /* Stack size in words */
+        STACK_SIZE,             /* Stack size in words */
         this,                   /* Task input parameter */
         2,                      /* Priority of the task */
-        &m_audioTaskHandle,     /* Task handle. */
+        xStack,                 /* Static stack handle */
+        &xTaskBuffer,           /* Task buffer. */
         m_audioTaskCoreId       /* Core where the task should run */
     );
 }

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -255,6 +255,10 @@ private:
   void            audioTask();
   void            performAudioTask();
 
+  inline static constexpr const size_t STACK_SIZE = 3300;
+  StaticTask_t xTaskBuffer;
+  StackType_t  xStack[STACK_SIZE];
+
   //+++ W E B S T R E A M  -  H E L P   F U N C T I O N S +++
   uint16_t readMetadata(uint16_t b, bool first = false);
   size_t   chunkedDataTransfer(uint8_t* bytes);


### PR DESCRIPTION
Moved task memory from the heap to reduce memory fragmentation.