### PR TITLE
Reset vuMeter when starting a new connection

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -548,7 +548,7 @@ bool Audio::connecttohost(const char* host, const char* user, const char* pwd) {
 //    ssl?|   |<-----host without extension-------->|port|<----- --extension----------->|<-first parameter->|<-second parameter->.......
 
     xSemaphoreTakeRecursive(mutex_playAudioData, 0.3 * configTICK_RATE_HZ);
-
+    m_vuLeft = m_vuRight = 0;
     if (host == NULL)              { AUDIO_INFO("Hostaddress is empty");     stopSong(); goto exit;}
     if (strlen(host) > 2048)       { AUDIO_INFO("Hostaddress is too long");  stopSong(); goto exit;} // max length in Chrome DevTools
 


### PR DESCRIPTION
Resetting m_vuLeft and m_VuRight avoid to get a wrong vulevel (!=0) during connection to a new host, Without this when you change url getVUlevel() return last values from old url...