### PR TITLE
LabRat: Check buffer size against file length for small files

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -3158,7 +3158,8 @@ void Audio::processLocalFile() {
                 m_f_running = false;
                 return;
             }
-            if(InBuff.bufferFilled() > maxFrameSize) { // read the file header first
+            if((InBuff.bufferFilled() > maxFrameSize) ||
+               (InBuff.bufferFilled() == m_fileSize)) { // read the file header first
                 InBuff.bytesWasRead(readAudioHeader(InBuff.getMaxAvailableBytes()));
             }
             return;


### PR DESCRIPTION
[Fix for issue #850](https://github.com/schreibfaul1/ESP32-audioI2S/issues/850) :  Ensure files less than maxFrameSize can still be passed to readAudioHeader function. 