### PR TITLE
Move forceMono processing before volume control

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2415,13 +2415,13 @@ void Audio::playChunk() {
             IIR_filterChain2(*sample);
         }
         //------------------------------------------------------------------
-        Gain(*sample);
-
         if(m_f_forceMono){
             int32_t xy = ((*sample)[RIGHTCHANNEL] + (*sample)[LEFTCHANNEL]) / 2;
             (*sample)[RIGHTCHANNEL] = (int16_t)xy;
             (*sample)[LEFTCHANNEL]  = (int16_t)xy;
         }
+        
+        Gain(*sample);
 
         if(m_f_internalDAC) {
             s2 = *sample;


### PR DESCRIPTION
This PR modifies the audio processing order to apply mono conversion before volume control.

Change made:
Moved the forceMono processing before the Gain function

Current Problems:
1. Pre-forceMono Balance Distortion:
With the current code, you can change the volume of the left and right channels independently. It can create an unintended effect as follows:
The original stereo balance is altered first by setting the volume of the left and right channels differently.
Then these imbalanced channels are averaged to create the mono signal.
This results in a mono output that doesn't represent the intended mono downmix of the original stereo source.

2. Post-forceMono Control Issue:
You can not adjust the volume levels of the left and right channels separately after the forceMono downmixing. This limits the ability to control the final L/R balance in mono playback.

The correct approach would be to:
First perform the mono downmixing (averaging the original L/R singals, that is what forceMono does).
Then apply volume adjustments to the mono signal.



