### PR TITLE
readMetadata: return on read failure

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -5884,6 +5884,10 @@ uint16_t Audio::readMetadata(uint16_t maxBytes, bool first) {
 
     if(!metalen) {
         int b = _client->read(); // First byte of metadata?
+        if (b < 0) {
+            AUDIO_INFO("client->read() failed (%d)", b);
+            return 0;
+        }
         metalen = b * 16;        // New count for metadata including length byte, max 4096
         pos_ml = 0;
         m_chbuf[pos_ml] = 0; // Prepare for new line


### PR DESCRIPTION
this read error can happen and will totally desynchronize the reader task.

Maybe the AUDIO_INFO can be left out, but it lets you easily see if and how often this happens :-)