### PR TITLE
move C-style structs within the class to a separate ns

### DIFF
--- a/src/Audio.h
+++ b/src/Audio.h
@@ -29,13 +29,17 @@
 #include <NetworkClient.h>
 #include <NetworkClientSecure.h>
 #include <driver/i2s_std.h>
-#include "psram_unique_ptr.hpp"
+#include "audiolib_structs.hpp"
 
 #ifndef I2S_GPIO_UNUSED
   #define I2S_GPIO_UNUSED -1 // = I2S_PIN_NO_CHANGE in IDF < 5
 #endif
 
 extern __attribute__((weak)) void audio_process_i2s(int16_t* outBuff, int32_t validSamples, bool *continueI2S); // record audiodata or send via BT
+extern char audioI2SVers[];
+
+// Audio event type descriptions
+static constexpr char* eventStr[13] = {"info", "id3data", "eof", "station_name", "icy_description", "streamtitle", "bitrate", "icy_url", "icy_logo", "lasthost", "cover_image", "lyrics", "log"};
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -103,333 +107,10 @@ protected:
 };
 //----------------------------------------------------------------------------------------------------------------------
 
-static const size_t AUDIO_STACK_SIZE = 3300;
-static StaticTask_t __attribute__((unused)) xAudioTaskBuffer;
-static StackType_t  __attribute__((unused)) xAudioStack[AUDIO_STACK_SIZE];
-extern char audioI2SVers[];
 
 class Audio{
 
     AudioBuffer InBuff; // instance of input buffer
-
-private:
-    typedef struct _SYLT{
-        bool         seen;
-        size_t       size;
-        uint32_t     pos;
-        char         lang[5];
-        uint8_t      text_encoding;
-        uint8_t      time_stamp_format;
-        uint8_t      content_type;
-    } sylt_t;
-    typedef struct _ID3Hdr{ // used only in readID3header()
-        size_t       retvalue;
-        size_t       headerSize;
-        size_t       tagSize;
-        size_t       cnt;
-        size_t       id3Size;
-        size_t       totalId3Size; // if we have more header, id3_1_size + id3_2_size + ....
-        size_t       remainingHeaderBytes;
-        size_t       universal_tmp;
-        uint8_t      ID3version;
-        uint8_t      ID3revision;
-        uint8_t      flags;
-        bool         unsync;
-        bool         extended_header;
-        bool         experimental_indicator;
-        bool         footer_present;
-        size_t       offset;
-        size_t       currentPosition;
-        int          ehsz;
-        char         tag[5];
-        char         frameid[5];
-        char         lang[5];
-        size_t       framesize;
-        bool         compressed;
-        size_t       APIC_size[3];
-        uint32_t     APIC_pos[3];
-        sylt_t       SYLT;
-        uint8_t      numID3Header;
-        uint16_t     iBuffSize;
-        uint8_t      contentDescriptorTerminator_0;
-        uint8_t      contentDescriptorTerminator_1;
-        uint8_t      textStringTerminator_0;
-        uint8_t      textStringTerminator_1;
-        bool         byteOrderMark;
-        ps_ptr<char> iBuff;
-    } ID3Hdr_t;
-    ID3Hdr_t m_ID3Hdr;
-
-    typedef struct _pwsHLS{  // used in processWebStreamHLS()
-        uint16_t     maxFrameSize;
-        uint16_t     ID3BuffSize;
-        uint32_t     availableBytes;
-        bool         firstBytes;
-        bool         f_chunkFinished;
-        uint32_t     byteCounter;
-        size_t       chunkSize;
-        uint16_t     ID3WritePtr;
-        uint16_t     ID3ReadPtr;
-        ps_ptr<uint8_t>ID3Buff;
-    } pwsHLS_t;
-    pwsHLS_t m_pwsHLS;
-
-    typedef struct _pplM3U8{ // used in parsePlaylist_M3U8
-        uint64_t     xMedSeq;
-        bool         f_mediaSeq_found;
-    } pplM3u8_t;
-    pplM3u8_t m_pplM3U8;
-
-    typedef struct _m4aHdr{ // used in read_M4A_Header
-        size_t      headerSize;
-        size_t      retvalue;
-        size_t      atomsize;
-        size_t      sizeof_ftyp;
-        size_t      sizeof_moov;
-        size_t      sizeof_free;
-        size_t      sizeof_mdat;
-        size_t      sizeof_trak;
-        size_t      sizeof_ilst;
-        size_t      sizeof_esds;
-        size_t      sizeof_mdia;
-        size_t      sizeof_minf;
-        size_t      sizeof_mdhd;
-        size_t      sizeof_stbl;
-        size_t      sizeof_stsd;
-        size_t      sizeof_stsz;
-        size_t      sizeof_mp4a;
-        size_t      sizeof_udta;
-        size_t      sizeof_meta;
-        size_t      audioDataPos;
-        size_t      cnt;
-        size_t      offset;
-        uint32_t    picPos;
-        uint32_t    picLen;
-        uint32_t    ilst_pos;
-        uint8_t     channel_count;
-        uint8_t     sample_size; // bps
-        uint8_t     objectTypeIndicator; // esds
-        uint8_t     streamType;   // esds
-        uint32_t    bufferSizeDB; // esds
-        uint32_t    maxBitrate;   // esds
-        uint32_t    nomBitrate;   // esds
-        uint32_t    timescale; // mdhd
-        uint32_t    duration;  // mdhd
-        uint16_t    sample_rate;
-        uint8_t     aac_profile;
-        uint32_t    stsz_num_entries;
-        uint32_t    stsz_table_pos;
-        bool        progressive; // Progressive (moov before mdat)
-        bool        version_flags;
-    } m4aHdr_t;
-    m4aHdr_t m_m4aHdr;
-
-    typedef struct _plCh{ // used in playChunk
-        int32_t     validSamples;
-        int32_t     samples48K = 0;
-        uint32_t    count = 0;
-        size_t      i2s_bytesConsumed;
-        int16_t*    sample[2];
-        int16_t*    s2;
-        int         sampleSize;
-        esp_err_t   err;
-        int         i;
-    } plCh_t;
-    plCh_t m_plCh;
-
-    typedef struct _lVar{ // used in loop
-        uint8_t     no_host_cnt;
-        uint32_t    no_host_timer;
-        uint8_t     count;
-    } lVar_t;
-    lVar_t m_lVar;
-
-    typedef struct _hwoe{ // used in dismantle_host
-        bool ssl;
-        ps_ptr<char> hwoe;      // host without extension
-        ps_ptr<char> rqh_host;  // host in request header
-        uint16_t     port;
-        ps_ptr<char> extension;
-        ps_ptr<char> query_string;
-    } hwoe_t;
-
-    typedef struct _prlf{ // used in processLocalFile
-        uint32_t  ctime;
-        int32_t   newFilePos;
-        bool      audioHeaderFound;
-        uint32_t  timeout;
-        uint32_t  maxFrameSize;
-        uint32_t  availableBytes;
-        int32_t   bytesAddedToBuffer;
-    } prlf_t;
-    prlf_t m_prlf;
-
-    typedef struct _cat { // used in calculateAudioTime
-        uint64_t sumBytesIn;
-        uint64_t sumBytesOut;
-        uint32_t sumBitRate;
-        uint32_t counter;
-        uint32_t timeStamp;
-        uint32_t deltaBytesIn;
-        uint32_t nominalBitRate;
-        uint32_t avrBitRate;
-        uint16_t syltIdx;
-    } cat_t;
-    cat_t m_cat;
-
-    typedef struct _cVUl{ // used in computeVUlevel
-        uint8_t sampleArray[2][4][8] = {0};
-        uint8_t cnt0 = 0, cnt1 = 0, cnt2 = 0, cnt3 = 0, cnt4 = 0;
-        bool    f_vu = false;
-    } cVUl_t;
-    cVUl_t m_cVUl;
-
-    typedef struct _ifCh{ // used in IIR_filterChain0, 1, 2
-        float   inSample0[2];
-        float   outSample0[2];
-        int16_t iir_out0[2];
-        float   inSample1[2];
-        float   outSample1[2];
-        int16_t iir_out1[2];
-        float   inSample2[2];
-        float   outSample2[2];
-        int16_t iir_out2[2];
-    } ifCh_t;
-    ifCh_t m_ifCh;
-
-    typedef struct _tspp{ // used in ts_parsePacket
-        int pidNumber = 0;
-        int pids[4]; // PID_ARRAY_LEN
-        int PES_DataLength = 0;
-        int pidOfAAC = 0;
-        uint8_t fillData = 0;
-    } tspp_t;
-    tspp_t m_tspp;
-
-    typedef struct _pwst{ // used in processWebStream
-        uint16_t  maxFrameSize;
-        uint32_t  chunkSize =0;
-        bool      f_skipCRLF = false;
-        uint32_t  availableBytes;
-        bool      f_clientIsConnected;
-        uint8_t   readedBytes;
-    } pwst_t;
-    pwst_t m_pwst;
-
-    typedef struct _gchs{ // used in getChunkSize
-        bool f_skipCRLF;
-        bool isHttpChunked;
-        size_t transportLimit;
-    } gchs_t;
-    gchs_t m_gchs;
-
-    typedef struct _pwf{ // used in processWebFile
-        uint32_t  maxFrameSize;
-        int32_t   newFilePos;
-        bool      audioHeaderFound;
-        uint32_t  chunkSize;
-        size_t    audioDataCount;
-        uint32_t  byteCounter;
-        uint32_t  nextChunkCount;
-        bool      f_waitingForPayload = false;
-        bool      f_clientIsConnected;
-        uint32_t  ctime;
-        uint32_t  timeout;
-        uint32_t  availableBytes;
-        int32_t   bytesAddedToBuffer;
-    } pwf_t;
-    pwf_t m_pwf;
-
-    typedef struct  _pad{ // used in playAudioData
-        uint8_t  count = 0;
-        size_t   oldAudioDataSize = 0;
-        bool     lastFrames = false;
-        int32_t  bytesToDecode;
-        int16_t  bytesDecoded;
-    } pad_t;
-    pad_t m_pad;
-
-    typedef struct _sbyt{ // used in sendBytes
-        int32_t  bytesLeft;
-        bool     f_setDecodeParamsOnce = true;
-        uint8_t  channels = 0;
-        int      nextSync = 0;
-        uint8_t  isPS = 0;
-    } sbyt_t;
-    sbyt_t m_sbyt;
-
-    typedef struct _rmet{ // used in readMetadata
-        uint16_t pos_ml = 0; // determines the current position in metaline
-        uint16_t metalen = 0;
-        uint16_t res = 0;
-    } rmet_t;
-    rmet_t m_rmet;
-
-    typedef struct _pwsts {                // used in processWebStreamTS
-        uint32_t       availableBytes;     // available bytes in stream
-        bool           f_firstPacket;
-        bool           f_chunkFinished;
-        bool           f_nextRound;
-        uint32_t       byteCounter;        // count received data
-        uint8_t        ts_packetStart = 0;
-        uint8_t        ts_packetLength = 0;
-        uint8_t        ts_packetPtr = 0;
-        const uint8_t  ts_packetsize = 188;
-        ps_ptr<uint8_t> ts_packet;
-        size_t         chunkSize = 0;
-    } pwsts_t;
-    pwsts_t m_pwsst;
-
-    typedef struct _rwh { // used in read_WAV_Header
-        size_t   headerSize;
-        uint32_t cs = 0;
-        uint8_t  bts = 0;
-    } rwh_t;
-    rwh_t m_rwh;
-
-    typedef struct _rflh { // used in read_FLAC_Header
-        size_t   headerSize;
-        size_t   retvalue;
-        bool     f_lastMetaBlock;
-        uint32_t picPos;
-        uint32_t picLen;
-        uint32_t duration;
-        uint32_t nominalBitrate;
-    } rflh_t;
-    rflh_t m_rflh;
-
-    typedef struct _phreh{ // used in parseHttpResponseHeader
-        uint32_t ctime;
-        uint32_t timeout;
-        uint32_t stime;
-        uint32_t bitrate;
-        bool     f_time = false;
-        bool     f_icy_data = false;
-    } phreh_t;
-    phreh_t m_phreh;
-
-    typedef struct _phrah{ // used in parseHttpRangeHeader
-        uint32_t ctime;
-        uint32_t timeout;
-        uint32_t stime;
-        bool     f_time = false;
-    } phrah_t;
-    phrah_t m_phrah;
-
-    typedef struct _sdet{ // used in streamDetection
-        uint32_t tmr_slow = 0;
-        uint32_t tmr_lost = 0;
-        uint8_t  cnt_slow = 0;
-        uint8_t  cnt_lost = 0;
-    }sdet_t;
-    sdet_t m_sdet;
-
-    typedef struct _fnsy{ // used in findNextSync
-        int      nextSync = 0;
-        uint32_t swnf = 0;
-    } fnsy_t;
-    fnsy_t m_fnsy;
-
 
   public:
 
@@ -438,7 +119,6 @@ private:
 
 // callbacks ---------------------------------------------------------
     typedef enum {evt_info = 0, evt_id3data, evt_eof, evt_name, evt_icydescription, evt_streamtitle, evt_bitrate, evt_icyurl, evt_icylogo, evt_lasthost, evt_image, evt_lyrics, evt_log} event_t;
-    const char* eventStr[13] = {"info", "id3data", "eof", "station_name", "icy_description", "streamtitle", "bitrate", "icy_url", "icy_logo", "lasthost", "cover_image", "lyrics", "log"};
     typedef struct _msg{ // used in info(audio_info_callback());
         const char* msg = nullptr;
         const char* s = nullptr;
@@ -452,7 +132,7 @@ private:
 // -------------------------------------------------------------------
 
     bool         openai_speech(const String& api_key, const String& model, const String& input, const String& instructions, const String& voice, const String& response_format, const String& speed);
-    hwoe_t       dismantle_host(const char* host);
+    audiolib::hwoe_t       dismantle_host(const char* host);
     bool         connecttohost(const char* host, const char* user = "", const char* pwd = "");
     bool         connecttospeech(const char* speech, const char* lang);
     bool         connecttoFS(fs::FS& fs, const char* path, int32_t fileStartTime = -1);
@@ -886,15 +566,6 @@ private:
     std::vector<uint32_t>     m_syltTimeStamp;          // SYLT time table
     std::vector<uint32_t>     m_hashQueue;
 
-    const size_t    m_frameSizeWav       = 4096;
-    const size_t    m_frameSizeMP3       = 1600 * 2;
-    const size_t    m_frameSizeAAC       = 1600;
-    const size_t    m_frameSizeFLAC      = 4096 * 6; // 24576
-    const size_t    m_frameSizeOPUS      = 2048;
-    const size_t    m_frameSizeVORBIS    = 4096 * 2;
-    const size_t    m_outbuffSize        = 4096 * 2;
-    const size_t    m_samplesBuff48KSize = m_outbuffSize * 8; // 131072KB  SRmin: 6KHz -> SRmax: 48K
-
     static const uint8_t m_tsPacketSize  = 188;
     static const uint8_t m_tsHeaderSize  = 4;
 
@@ -1025,6 +696,33 @@ private:
     int16_t         m_pidOfAAC;
     uint8_t         m_packetBuff[m_tsPacketSize];
     int16_t         m_pesDataLength = 0;
+
+    // audiolib structs
+    audiolib::ID3Hdr_t m_ID3Hdr;
+    audiolib::pwsHLS_t m_pwsHLS;
+    audiolib::pplM3u8_t m_pplM3U8;
+    audiolib::m4aHdr_t m_m4aHdr;
+    audiolib::plCh_t m_plCh;
+    audiolib::lVar_t m_lVar;
+    audiolib::prlf_t m_prlf;
+    audiolib::cat_t m_cat;
+    audiolib::cVUl_t m_cVUl;
+    audiolib::ifCh_t m_ifCh;
+    audiolib::tspp_t m_tspp;
+    audiolib::pwst_t m_pwst;
+    audiolib::gchs_t m_gchs;
+    audiolib::pwf_t m_pwf;
+    audiolib::pad_t m_pad;
+    audiolib::sbyt_t m_sbyt;
+    audiolib::rmet_t m_rmet;
+    audiolib::pwsts_t m_pwsst;
+    audiolib::rwh_t m_rwh;
+    audiolib::rflh_t m_rflh;
+    audiolib::phreh_t m_phreh;
+    audiolib::phrah_t m_phrah;
+    audiolib::sdet_t m_sdet;
+    audiolib::fnsy_t m_fnsy;
+
 
 //----------------------------------------------------------------------------------------------------------------------
     template <typename... Args>

--- a/src/audiolib_structs.hpp
+++ b/src/audiolib_structs.hpp
@@ -1,0 +1,303 @@
+#pragma once
+#include "psram_unique_ptr.hpp"
+#include <stddef.h>
+#include <cstdint>
+
+// this file contains definitions of various structs used in Audio lib
+
+namespace audiolib {
+    struct sylt_t {
+        bool         seen;
+        size_t       size;
+        uint32_t     pos;
+        char         lang[5];
+        uint8_t      text_encoding;
+        uint8_t      time_stamp_format;
+        uint8_t      content_type;
+    };
+
+    struct ID3Hdr_t { // used only in readID3header()
+        size_t       retvalue;
+        size_t       headerSize;
+        size_t       tagSize;
+        size_t       cnt;
+        size_t       id3Size;
+        size_t       totalId3Size; // if we have more header, id3_1_size + id3_2_size + ....
+        size_t       remainingHeaderBytes;
+        size_t       universal_tmp;
+        uint8_t      ID3version;
+        uint8_t      ID3revision;
+        uint8_t      flags;
+        bool         unsync;
+        bool         extended_header;
+        bool         experimental_indicator;
+        bool         footer_present;
+        size_t       offset;
+        size_t       currentPosition;
+        int          ehsz;
+        char         tag[5];
+        char         frameid[5];
+        char         lang[5];
+        size_t       framesize;
+        bool         compressed;
+        size_t       APIC_size[3];
+        uint32_t     APIC_pos[3];
+        sylt_t       SYLT;
+        uint8_t      numID3Header;
+        uint16_t     iBuffSize;
+        uint8_t      contentDescriptorTerminator_0;
+        uint8_t      contentDescriptorTerminator_1;
+        uint8_t      textStringTerminator_0;
+        uint8_t      textStringTerminator_1;
+        bool         byteOrderMark;
+        ps_ptr<char> iBuff;
+    };
+
+    struct pwsHLS_t {  // used in processWebStreamHLS()
+        uint16_t     maxFrameSize;
+        uint16_t     ID3BuffSize;
+        uint32_t     availableBytes;
+        bool         firstBytes;
+        bool         f_chunkFinished;
+        uint32_t     byteCounter;
+        size_t       chunkSize;
+        uint16_t     ID3WritePtr;
+        uint16_t     ID3ReadPtr;
+        ps_ptr<uint8_t>ID3Buff;
+    };
+
+    struct pplM3u8_t { // used in parsePlaylist_M3U8
+        uint64_t     xMedSeq;
+        bool         f_mediaSeq_found;
+    };
+
+    struct m4aHdr_t { // used in read_M4A_Header
+        size_t      headerSize;
+        size_t      retvalue;
+        size_t      atomsize;
+        size_t      sizeof_ftyp;
+        size_t      sizeof_moov;
+        size_t      sizeof_free;
+        size_t      sizeof_mdat;
+        size_t      sizeof_trak;
+        size_t      sizeof_ilst;
+        size_t      sizeof_esds;
+        size_t      sizeof_mdia;
+        size_t      sizeof_minf;
+        size_t      sizeof_mdhd;
+        size_t      sizeof_stbl;
+        size_t      sizeof_stsd;
+        size_t      sizeof_stsz;
+        size_t      sizeof_mp4a;
+        size_t      sizeof_udta;
+        size_t      sizeof_meta;
+        size_t      audioDataPos;
+        size_t      cnt;
+        size_t      offset;
+        uint32_t    picPos;
+        uint32_t    picLen;
+        uint32_t    ilst_pos;
+        uint8_t     channel_count;
+        uint8_t     sample_size; // bps
+        uint8_t     objectTypeIndicator; // esds
+        uint8_t     streamType;   // esds
+        uint32_t    bufferSizeDB; // esds
+        uint32_t    maxBitrate;   // esds
+        uint32_t    nomBitrate;   // esds
+        uint32_t    timescale; // mdhd
+        uint32_t    duration;  // mdhd
+        uint16_t    sample_rate;
+        uint8_t     aac_profile;
+        uint32_t    stsz_num_entries;
+        uint32_t    stsz_table_pos;
+        bool        progressive; // Progressive (moov before mdat)
+        bool        version_flags;
+    };
+
+    struct plCh_t { // used in playChunk
+        int32_t     validSamples;
+        int32_t     samples48K = 0;
+        uint32_t    count = 0;
+        size_t      i2s_bytesConsumed;
+        int16_t*    sample[2];
+        int16_t*    s2;
+        int         sampleSize;
+        esp_err_t   err;
+        int         i;
+    };
+
+    struct lVar_t { // used in loop
+        uint8_t     no_host_cnt;
+        uint32_t    no_host_timer;
+        uint8_t     count;
+    };
+
+    struct hwoe_t { // used in dismantle_host
+        bool ssl;
+        ps_ptr<char> hwoe;      // host without extension
+        ps_ptr<char> rqh_host;  // host in request header
+        uint16_t     port;
+        ps_ptr<char> extension;
+        ps_ptr<char> query_string;
+    };
+
+    struct prlf_t { // used in processLocalFile
+        uint32_t  ctime;
+        int32_t   newFilePos;
+        bool      audioHeaderFound;
+        uint32_t  timeout;
+        uint32_t  maxFrameSize;
+        uint32_t  availableBytes;
+        int32_t   bytesAddedToBuffer;
+    };
+
+    struct cat_t { // used in calculateAudioTime
+        uint64_t sumBytesIn;
+        uint64_t sumBytesOut;
+        uint32_t sumBitRate;
+        uint32_t counter;
+        uint32_t timeStamp;
+        uint32_t deltaBytesIn;
+        uint32_t nominalBitRate;
+        uint32_t avrBitRate;
+        uint16_t syltIdx;
+    };
+
+    struct cVUl_t { // used in computeVUlevel
+        uint8_t sampleArray[2][4][8] = {0};
+        uint8_t cnt0 = 0, cnt1 = 0, cnt2 = 0, cnt3 = 0, cnt4 = 0;
+        bool    f_vu = false;
+    };
+
+    struct ifCh_t { // used in IIR_filterChain0, 1, 2
+        float   inSample0[2];
+        float   outSample0[2];
+        int16_t iir_out0[2];
+        float   inSample1[2];
+        float   outSample1[2];
+        int16_t iir_out1[2];
+        float   inSample2[2];
+        float   outSample2[2];
+        int16_t iir_out2[2];
+    };
+
+    struct tspp_t{ // used in ts_parsePacket
+        int pidNumber = 0;
+        int pids[4]; // PID_ARRAY_LEN
+        int PES_DataLength = 0;
+        int pidOfAAC = 0;
+        uint8_t fillData = 0;
+    };
+
+    struct pwst_t { // used in processWebStream
+        uint16_t  maxFrameSize;
+        uint32_t  chunkSize =0;
+        bool      f_skipCRLF = false;
+        uint32_t  availableBytes;
+        bool      f_clientIsConnected;
+        uint8_t   readedBytes;
+    };
+
+    struct gchs_t { // used in getChunkSize
+        bool f_skipCRLF;
+        bool isHttpChunked;
+        size_t transportLimit;
+    };
+
+    struct pwf_t { // used in processWebFile
+        uint32_t  maxFrameSize;
+        int32_t   newFilePos;
+        bool      audioHeaderFound;
+        uint32_t  chunkSize;
+        size_t    audioDataCount;
+        uint32_t  byteCounter;
+        uint32_t  nextChunkCount;
+        bool      f_waitingForPayload = false;
+        bool      f_clientIsConnected;
+        uint32_t  ctime;
+        uint32_t  timeout;
+        uint32_t  availableBytes;
+        int32_t   bytesAddedToBuffer;
+    };
+
+    struct  pad_t { // used in playAudioData
+        uint8_t  count = 0;
+        size_t   oldAudioDataSize = 0;
+        bool     lastFrames = false;
+        int32_t  bytesToDecode;
+        int16_t  bytesDecoded;
+    };
+
+    struct sbyt_t { // used in sendBytes
+        int32_t  bytesLeft;
+        bool     f_setDecodeParamsOnce = true;
+        uint8_t  channels = 0;
+        int      nextSync = 0;
+        uint8_t  isPS = 0;
+    };
+
+    struct rmet_t { // used in readMetadata
+        uint16_t pos_ml = 0; // determines the current position in metaline
+        uint16_t metalen = 0;
+        uint16_t res = 0;
+    };
+
+    struct pwsts_t {                // used in processWebStreamTS
+        uint32_t       availableBytes;     // available bytes in stream
+        bool           f_firstPacket;
+        bool           f_chunkFinished;
+        bool           f_nextRound;
+        uint32_t       byteCounter;        // count received data
+        uint8_t        ts_packetStart = 0;
+        uint8_t        ts_packetLength = 0;
+        uint8_t        ts_packetPtr = 0;
+        const uint8_t  ts_packetsize = 188;
+        ps_ptr<uint8_t> ts_packet;
+        size_t         chunkSize = 0;
+    };
+
+    struct rwh_t { // used in read_WAV_Header
+        size_t   headerSize;
+        uint32_t cs = 0;
+        uint8_t  bts = 0;
+    };
+
+    struct rflh_t { // used in read_FLAC_Header
+        size_t   headerSize;
+        size_t   retvalue;
+        bool     f_lastMetaBlock;
+        uint32_t picPos;
+        uint32_t picLen;
+        uint32_t duration;
+        uint32_t nominalBitrate;
+    };
+
+    struct phreh_t { // used in parseHttpResponseHeader
+        uint32_t ctime;
+        uint32_t timeout;
+        uint32_t stime;
+        uint32_t bitrate;
+        bool     f_time = false;
+        bool     f_icy_data = false;
+    };
+
+    struct phrah_t { // used in parseHttpRangeHeader
+        uint32_t ctime;
+        uint32_t timeout;
+        uint32_t stime;
+        bool     f_time = false;
+    };
+
+    struct sdet_t { // used in streamDetection
+        uint32_t tmr_slow = 0;
+        uint32_t tmr_lost = 0;
+        uint8_t  cnt_slow = 0;
+        uint8_t  cnt_lost = 0;
+    };
+
+    struct fnsy_t { // used in findNextSync
+        int      nextSync = 0;
+        uint32_t swnf = 0;
+    };
+
+}


### PR DESCRIPTION
refactoring C-style structs would help to keep Audio class definition clean and put private structs definitions away