### PR TITLE
Optimize playChunk() by bypassing Gain()

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -3424,10 +3424,13 @@ void IRAM_ATTR Audio::playChunk() {
     if (m_plCh.count > 0) goto i2swrite; // Not all samples could be written to I2S during the last run
     audio_process_raw_samples(m_outBuff.get(), m_validSamples);
     //------------------------------------------------------------------------------------------
-    for (int i = 0; i < m_validSamples; i++) {
-        if (settings.VU_LEVEL) calculateVUlevel(&m_outBuff[i * 2]);
-        if (settings.IIR_FILTER) IIR_filter(&m_outBuff[i * 2]);
-        Gain(&m_outBuff[i * 2]);
+    {
+        const bool applyGain = settings.VOLUME_CONTROL && (m_audio_items.limiter[LEFTCHANNEL] != 1.0f || m_audio_items.limiter[RIGHTCHANNEL] != 1.0f);
+        for (int i = 0; i < m_validSamples; i++) {
+            if (settings.VU_LEVEL) calculateVUlevel(&m_outBuff[i * 2]);
+            if (settings.IIR_FILTER) IIR_filter(&m_outBuff[i * 2]);
+            if (applyGain) Gain(&m_outBuff[i * 2]);
+        }
     }
     if (settings.SPECTRUM) processSpectrum();
     if (m_f_forceMono) stereo2mono(m_outBuff.get(), m_validSamples);

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -374,6 +374,7 @@ class Audio {
         bool     VU_LEVEL = true;          // true: vu meter is enabled
         bool     IIR_FILTER = true;        // true: IIR filter (highshelf, bandpass, lowshelf) are enabled
         bool     SPECTRUM = false;         // true: spectrum analyzer is enabled
+        bool     VOLUME_CONTROL = true;    // true: volume and balance control is enabled
         float    VOL_FADING_SPEED = 50.0;  // mute, volume fading 1.0f (fast) ... 100.0f (slow)
     } settings;
 


### PR DESCRIPTION
It allows for disabling the gain control when using an external DAC with its own DSP.