### PR TITLE
Fix early EOF with MP3 files containing large ID3/APIC tags

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -4091,7 +4091,9 @@ void Audio::processLocalFile() {
         m_prlf.newFilePos = newInBuffStart(m_resumeFilePos);
         if (m_prlf.newFilePos < 0) AUDIO_LOG_WARN("skip to new position was not successful");
         m_haveNewFilePos = m_prlf.newFilePos;
-        m_audioDataReadPtr = m_prlf.newFilePos;
+        m_audioDataReadPtr = (m_prlf.newFilePos > (int32_t)m_audioDataStart)
+                                 ? (m_prlf.newFilePos - m_audioDataStart)
+                                 : 0;
         m_resumeFilePos = -1;
         m_f_allDataReceived = false;
         return;
@@ -4100,7 +4102,7 @@ void Audio::processLocalFile() {
     m_prlf.availableBytes = min(InBuff.writeSpace(), (size_t)(m_audioFileSize - m_audioFilePosition));
     m_prlf.bytesAddedToBuffer = audioFileRead(InBuff.getWritePtr(), min(m_prlf.availableBytes, (uint32_t)UINT16_MAX));
     if (m_prlf.bytesAddedToBuffer > 0) { InBuff.bytesWritten(m_prlf.bytesAddedToBuffer); }
-    if (m_audioDataSize && m_audioFilePosition >= m_audioDataSize) {
+    if (m_audioDataSize && m_audioFilePosition >= m_audioDataStart + m_audioDataSize) {
         if (!m_f_allDataReceived) m_f_allDataReceived = true;
     }
     if (!m_audioDataSize && m_audioFilePosition == m_audioFileSize) {
@@ -4289,7 +4291,9 @@ void Audio::processWebFile() {
         m_pwf.newFilePos = newInBuffStart(m_resumeFilePos);
         if (m_pwf.newFilePos < 0) AUDIO_LOG_WARN("skip to new position was not successful");
         m_haveNewFilePos = m_pwf.newFilePos;
-        m_audioDataReadPtr = m_pwf.newFilePos;
+        m_audioDataReadPtr = (m_pwf.newFilePos > (int32_t)m_audioDataStart)
+                                 ? (m_pwf.newFilePos - m_audioDataStart)
+                                 : 0;
         m_resumeFilePos = -1;
         m_f_allDataReceived = false;
         return;
@@ -4298,7 +4302,7 @@ void Audio::processWebFile() {
     m_pwf.availableBytes = min(m_client->available(), (int)InBuff.writeSpace());
     m_pwf.bytesAddedToBuffer = audioFileRead(InBuff.getWritePtr(), min(m_pwf.availableBytes, (uint32_t)UINT16_MAX));
     if (m_pwf.bytesAddedToBuffer > 0) { InBuff.bytesWritten(m_pwf.bytesAddedToBuffer); }
-    if (m_audioDataSize && m_audioFilePosition >= m_audioDataSize) {
+    if (m_audioDataSize && m_audioFilePosition >= m_audioDataStart + m_audioDataSize) {
         if (!m_f_allDataReceived) m_f_allDataReceived = true;
     }
     if (!m_audioDataSize && m_audioFilePosition == m_audioFileSize) {
@@ -4678,21 +4682,24 @@ void Audio::playAudioData() {
         m_pad.bytesDecoded = 0;
         if (isFile) {
             if (!m_audioDataSize) goto exit; // no data to decode if filesize is 0
-            if (m_audioDataStart + m_audioDataSize - m_audioDataReadPtr == 128) {
+            size_t audioBytesRemaining = (m_audioDataReadPtr < m_audioDataSize)
+                                             ? (m_audioDataSize - m_audioDataReadPtr)
+                                             : 0;
+            if (audioBytesRemaining == 128) {
                 m_f_ID3v1TagFound = true;
                 m_f_eof = true;
                 goto exit;
             }
-            if (m_audioDataSize <= m_audioDataReadPtr) {
+            if (!audioBytesRemaining) {
                 m_f_eof = true;
                 goto exit;
             }
 
-            if (m_audioDataStart + m_audioDataSize >= m_audioFilePosition) m_f_allDataReceived = true;
-            if (m_audioDataSize - m_audioDataReadPtr <= InBuff.getMaxBlockSize()) m_pad.lastFrames = true;
+            if (m_audioFilePosition >= m_audioDataStart + m_audioDataSize) m_f_allDataReceived = true;
+            if (audioBytesRemaining <= InBuff.getMaxBlockSize()) m_pad.lastFrames = true;
 
             if (m_pad.lastFrames) {
-                m_pad.bytesToDecode = min(InBuff.readSpace(), (size_t)(m_audioDataStart + m_audioDataSize - m_audioDataReadPtr));
+                m_pad.bytesToDecode = min(InBuff.readSpace(), audioBytesRemaining);
                 m_pad.bytesDecoded = sendBytes(InBuff.getReadPtr(), m_pad.bytesToDecode);
             } else {
                 m_pad.bytesToDecode = InBuff.readSpace();
@@ -5956,7 +5963,7 @@ bool Audio::setAudioFilePosition(uint32_t pos) {
     }
     if (pos < m_audioDataStart) {
         AUDIO_LOG_WARN("set audiodatastart at {}", m_audioDataStart);
-        m_resumeFilePos = m_audioDataStart;
+        pos = m_audioDataStart;
     }
     m_resumeFilePos = pos;
 
@@ -7164,7 +7171,8 @@ int32_t Audio::newInBuffStart(int32_t resumeFilePos) {
     // keep resumeFilePos within the audio data
     if (resumeFilePos < (int32_t)m_audioDataStart) resumeFilePos = m_audioDataStart;
 
-    uint32_t buffFillValue = std::min<uint32_t>(m_audioDataSize - resumeFilePos, UINT16_MAX);
+    uint32_t audioDataEnd = m_audioDataStart + m_audioDataSize;
+    uint32_t buffFillValue = std::min<uint32_t>(audioDataEnd - resumeFilePos, UINT16_MAX);
 
     AUDIO_LOG_DEBUG("new InBuff start at m_resumeFilePos {}, m_audioDataStart {}", m_resumeFilePos, m_audioDataStart);
 


### PR DESCRIPTION
## Summary

This PR fixes an early EOF issue with MP3 files containing large ID3v2/APIC tags.

In affected files, playback can stop too early, roughly proportional to the size of the ID3/APIC data before the actual audio stream.

The root cause is that some code paths mix absolute file positions with offsets relative to `m_audioDataStart`. `m_audioDataStart` marks the beginning of the actual audio data after ID3 tags, embedded cover images and padding. When this offset is large, EOF detection and remaining-byte calculations can become incorrect and playback may end before the real end of the audio data.

## Context

This issue was observed in ESPuino, where MP3 tracks stopped about 2 seconds too early in a setup using files with embedded cover images / larger ID3 tags.

The issue was discussed here:

https://forum.espuino.de/t/mp3-titel-hoeren-alle-2-sekunden-zu-frueh-auf/4543/13

## What changed

- Convert `newFilePos` from absolute file position to relative audio-data position before assigning it to `m_audioDataReadPtr`.
- Compare absolute file positions against the absolute audio end:
  `m_audioDataStart + m_audioDataSize`.
- Calculate remaining audio bytes relative to `m_audioDataSize`.
- Fix the seek clamp in `setAudioFilePosition()` so positions before `m_audioDataStart` are actually clamped.
- Fix `newInBuffStart()` to avoid subtracting an absolute file position from a relative audio-data size.

## Tested

Tested with ESPuino using MP3 files containing embedded cover images / larger ID3 tags.

A small 0.06 MB MP3 test file from this ESPuino forum post can be used to reproduce/test the issue:

https://forum.espuino.de/t/einige-mp3s-starten-nicht/4551/9?u=joker

Direct download links from that post:

https://forum.espuino.de/uploads/default/original/2X/f/fd17bfc48436c3d45f26b9d14a1c3124ac69fc00.mp3

Before this fix, affected MP3 files stopped before reaching the actual end of the audio data. With this fix, playback reaches the actual end of the file.