### PR TITLE
Fix corrupted playback position when rewinding past track start via setTimeOffset()

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -6161,6 +6161,13 @@ bool Audio::setTimeOffset(int sec) { // fast forward or rewind the current posit
     int32_t  offset = oneSec * sec;     // bytes to be wind/rewind
     int32_t  pos = m_audioFilePosition - inBufferFilled();
     pos += offset;
+    // Rewinding by more seconds than have already elapsed (e.g. seeking backwards near the start
+    // of the track) can push pos below m_audioDataStart. Without this clamp, m_resumeFilePos ends
+    // up smaller than m_audioDataStart, and (m_resumeFilePos - m_audioDataStart) below underflows
+    // (int32_t - uint32_t promotes to unsigned) to a huge value that corrupts m_cat.sum_samples and,
+    // downstream, the reported playback position/duration. setAudioFilePosition() already guards
+    // against this same case; setTimeOffset() needs the same floor.
+    if (pos < (int32_t) m_audioDataStart) pos = m_audioDataStart;
     m_resumeFilePos = pos;
     m_cat.sum_samples = (float)m_cat.tota_samples * ((float)(m_resumeFilePos - m_audioDataStart) / m_audioDataSize);
     return true;


### PR DESCRIPTION
setTimeOffset() clamps its local "newTime" bounds-check variable to >= 0, but the actual resume-position calculation (pos/m_resumeFilePos) still uses the unclamped seek offset. Rewinding by more seconds than have already elapsed (e.g. seeking backwards near the start of a track) can therefore push pos below m_audioDataStart.

Since m_resumeFilePos is int32_t but m_audioDataStart is uint32_t, the subsequent (m_resumeFilePos - m_audioDataStart) in the sum_samples calculation promotes to unsigned and underflows to a huge value when m_resumeFilePos is smaller than m_audioDataStart, corrupting m_cat.sum_samples and everything derived from it (reported playback position/duration).

setAudioFilePosition() already guards against exactly this case:
    if (pos < m_audioDataStart) { m_resumeFilePos = m_audioDataStart; }
setTimeOffset() was missing the equivalent floor - add it.

Reported at https://forum.espuino.de/t/anzeige-und-verhalten-beim-zurueckspulen-komisch/4511 (ESPuino project, which calls setTimeOffset() for its rewind/fast-forward button actions). Build-verified against the ESPuino firmware; a full hardware playback test is pending.