### PR TITLE
Fix AAC mono streams losing L/R duplication

### DIFF
--- a/src/aac_decoder/aac_decoder.cpp
+++ b/src/aac_decoder/aac_decoder.cpp
@@ -2,7 +2,7 @@
  *  aac_decoder.cpp
  *  faad2 - ESP32 adaptation
  *  Created on: 12.09.2023
- *  Updated on: 16.07.2026
+ *  Updated on: 18.07.2026
  */
 
 #include "aac_decoder.h"
@@ -164,6 +164,13 @@ int32_t AACDecoder::decode(uint8_t* inbuf, int32_t* bytesLeft, int32_t* outbuf) 
             if(getErrorMessage(abs(err)).level == AAC_VERBOSE) AAC_LOG_VERBOSE("{}", getErrorMessage(abs(err)).text);
         }
     } else {
+        if (m_aacChannels == 1) {
+            for (int32_t i = m_validSamples - 1; i >= 0; i--) {
+                int32_t sample = outbuf[i];
+                outbuf[i * 2] = sample;
+                outbuf[i * 2 + 1] = sample;
+            }
+        }
     }
     return err;
 }


### PR DESCRIPTION
## Problem

`83a007a` (\"decoder copy directly in outbuff\") switched `AACDecoder::decode()` to have libfaad write its 32-bit output directly into `outbuf`, but it deleted the mono -> stereo duplication loop for AAC while the equivalent logic in mp3/vorbis was kept in the same commit.

For a real mono AAC/M4A stream (`m_aacChannels == 1`, libfaad's internal `upMatrix == 0`, true on all non-S3/P4 ESP32 targets since PS/SBR upsampling is compiled in only for `CONFIG_IDF_TARGET_ESP32S3`/`P4`), `to_PCM_32bit()` writes `frame_len` **contiguous** int32 samples starting at `outbuf[0]` with no L/R interleaving. Since `m_validSamples = getOutputSamples() / getChannels()` in `Audio.cpp` still assumes an interleaved stereo buffer, every decoded frame from a mono AAC stream currently comes out as garbled/stale sample pairs instead of the mono sample duplicated to both channels.

The same-day follow-up commit `05538efbda` (\"fix opus mono streams\") independently restores the identical duplication step for the Opus decoder, confirming this is a real bug class that was simply missed for AAC in `83a007a`.

## Fix

Restore an in-place, backward-iterating mono -> stereo duplication loop right after the successful decode, gated on `m_aacChannels == 1` so the stereo path (already correctly interleaved by libfaad) is untouched:

```cpp
if (m_aacChannels == 1) {
    for (int32_t i = m_validSamples - 1; i >= 0; i--) {
        int32_t sample = outbuf[i];
        outbuf[i * 2] = sample;
        outbuf[i * 2 + 1] = sample;
    }
}
```

Backward iteration avoids clobbering not-yet-read source samples, matching the idiom already used in `vorbis_decoder.cpp` and the same-day `opus_decoder.cpp` fix.

## Verification

Reproduced the bug arithmetically in a standalone host-side harness mirroring `AACDecoder::decode()`'s exact indexing (libfaad writing `frame_len` contiguous int32 samples, then the current `Audio.cpp` stereo-frame read pattern): with the pre-fix code, 8/8 simulated stereo frames from a mono stream came out corrupted (half read two distinct mono samples wrongly folded into one L/R pair, half read stale leftover buffer data from the previous frame). With the fix applied, all 8/8 frames are correct, and the stereo (`m_aacChannels == 2`) path is unaffected by construction since the new branch only triggers on `m_aacChannels == 1`.