### PR TITLE
Fix out of bounds read in SYLT lyrics parsing

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2522,11 +2522,10 @@ int Audio::read_ID3_Header(uint8_t* data, size_t len) {
             ps_ptr<char> content_descriptor;
             ps_ptr<char> syltBuff;
             bool         isBigEndian = true;
-            size_t       len = 0;
             int          idx = 0;
             m_ID3Hdr.SYLT.pos = m_ID3Hdr.id3Size - m_ID3Hdr.remainingHeaderBytes;
             m_ID3Hdr.SYLT.size = m_ID3Hdr.framesize;
-            if (m_ID3Hdr.SYLT.size < len) return 0;
+            if (m_ID3Hdr.SYLT.size > len) return 0; // not enough data buffered yet, wait for more
             syltBuff.copy_from(data, m_ID3Hdr.SYLT.size);
             m_ID3Hdr.SYLT.text_encoding = syltBuff[0]; // 0=ISO-8859-1, 1=UTF-16, 2=UTF-16BE, 3=UTF-8
             if (m_ID3Hdr.SYLT.text_encoding == 1) isBigEndian = false;
@@ -2625,12 +2624,11 @@ int Audio::read_ID3_Header(uint8_t* data, size_t len) {
                 ps_ptr<char> content_descriptor;
                 ps_ptr<char> syltBuff;
                 bool         isBigEndian = true;
-                size_t       len = 0;
                 int          idx = 0;
 
                 m_ID3Hdr.SYLT.pos = m_ID3Hdr.id3Size - m_ID3Hdr.remainingHeaderBytes;
                 m_ID3Hdr.SYLT.size = m_ID3Hdr.v22_tag_length;
-                if (m_ID3Hdr.SYLT.size < len) return 0;
+                if (m_ID3Hdr.SYLT.size > len) return 0; // not enough data buffered yet, wait for more
                 syltBuff.copy_from(data, m_ID3Hdr.SYLT.size);
                 m_ID3Hdr.SYLT.text_encoding = syltBuff[0];
                 memcpy(m_ID3Hdr.SYLT.lang, syltBuff.get() + 1, 3);
@@ -2641,13 +2639,14 @@ int Audio::read_ID3_Header(uint8_t* data, size_t len) {
 
                 idx = 6;
 
+                size_t descLen = 0;
                 if (m_ID3Hdr.SYLT.text_encoding == 0 || m_ID3Hdr.SYLT.text_encoding == 3) { // utf-8
-                    len = content_descriptor.copy_from(syltBuff.get() + idx);
+                    descLen = content_descriptor.copy_from(syltBuff.get() + idx);
                 } else { // utf-16
-                    len = content_descriptor.copy_from_utf16(syltBuff.get() + idx, isBigEndian);
+                    descLen = content_descriptor.copy_from_utf16(syltBuff.get() + idx, isBigEndian);
                 }
-                if (len > 2) info(*this, evt_info, "Lyrics: content_descriptor: {}", content_descriptor.c_get());
-                idx += len;
+                if (descLen > 2) info(*this, evt_info, "Lyrics: content_descriptor: {}", content_descriptor.c_get());
+                idx += descLen;
 
                 while (idx < m_ID3Hdr.SYLT.size) {
                     // UTF-16LE, UTF-16BE


### PR DESCRIPTION
Fixes #1380

Both places that handle synchronized lyrics in read_ID3_Header(), the SYLT block and the older ID3v2.2 SLT block, declared a local size_t len = 0 that shadowed the real len parameter the function receives, the one that actually tells you how many bytes are available in data for this call. Since the local was always 0 and size_t is unsigned, the bounds check right after it could never reject anything in either block.

Right after that dead check both blocks call copy_from(data, SYLT.size), where SYLT.size comes straight from the tag's own declared frame size. With the check disabled, a tag that claims a size bigger than what has actually been buffered causes copy_from to read past the end of data.

What this PR does:

- Removes both shadowing declarations
- Fixes the check to use the real len parameter with the correct comparison direction, so an oversized claim now returns 0 and the parser waits for more data instead of reading past the buffer
- The legacy SLT block also reused len further down for something unrelated, the length of a copied content descriptor. Renamed that one to descLen so it stays its own local and doesn't quietly start writing into the real function parameter now that the shadow is gone

How I checked this. I couldn't do a full firmware build in my environment since that needs the full ESP32 Arduino toolchain, so instead I pulled the real copy_from and alloc logic out of psram_unique_ptr.hpp into a small standalone harness and ran it under AddressSanitizer. Feeding it a 16 byte buffer with a claimed size of 4096, matching the shape of the real bug, produces a clean heap buffer overflow read inside copy_from before the fix, and a correct rejection after it. I also ran a control case with a normal, correctly sized request to make sure legitimate lyrics parsing still works the same as before, which it does.

Diff is intentionally small and limited to these two blocks, didn't touch anything else nearby.