### PR TITLE
fix(gain_ramp): skip calculateVolumeLimits() when volume/balance are unchanged

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -7045,7 +7045,14 @@ void Audio::gain_ramp() {
     else if (m_audio_items.cur_volume > m_audio_items.volume_steps)
         m_audio_items.cur_volume = m_audio_items.volume_steps;
 
-    calculateVolumeLimits();
+    // calculateVolumeLimits() is expensive (powf()); skip when nothing changed since last tick
+    if (!m_limiterComputed || m_audio_items.cur_volume != m_lastLimiterVolume ||
+        m_audio_items.balance != m_lastLimiterBalance) {
+        calculateVolumeLimits();
+        m_lastLimiterVolume  = m_audio_items.cur_volume;
+        m_lastLimiterBalance = m_audio_items.balance;
+        m_limiterComputed    = true;
+    }
 }
 // —————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void Audio::calculateVolumeLimits() { // is calculated when the volume or balance changes

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -706,6 +706,10 @@ class Audio {
     audiolib::sdet_t       m_sdet;
     audiolib::fnsy_t       m_fnsy;
     audiolib::audioItems_t m_audio_items;
+    // last inputs calculateVolumeLimits() ran against, so gain_ramp() can skip a repeat
+    bool  m_limiterComputed    = false;
+    float m_lastLimiterVolume  = 0.0f;
+    float m_lastLimiterBalance = 0.0f;
     audiolib::vu_items_t   m_vu_items;
     audiolib::fft_items_t  m_fft_items;
     audiolib::i2s_items_t  m_i2s_items;


### PR DESCRIPTION
Fixes #1385.

## What this changes

`gain_ramp()` calls `calculateVolumeLimits()` unconditionally, once per `performAudioTask()`
tick (~1 kHz), even though `calculateVolumeLimits()`'s own comment says it should run only
"when the volume or balance changes". Outside an active fade or a balance change, `cur_volume`
and `balance` are steady essentially all the time, so this was pure repeated work -- a handful
of `powf()` calls computing the same answer every tick, at rest, forever.

This PR caches what the limiter was last computed against and skips the call when neither input
moved:

```cpp
-    calculateVolumeLimits();
+    // calculateVolumeLimits() is expensive (powf()); skip when nothing changed since last tick
+    if (!m_limiterComputed || m_audio_items.cur_volume != m_lastLimiterVolume ||
+        m_audio_items.balance != m_lastLimiterBalance) {
+        calculateVolumeLimits();
+        m_lastLimiterVolume  = m_audio_items.cur_volume;
+        m_lastLimiterBalance = m_audio_items.balance;
+        m_limiterComputed    = true;
+    }
```

`m_limiterComputed` is a bool rather than an out-of-range sentinel float on purpose: `balance`'s
valid range (-16.0f..16.0f) and `cur_volume`'s (0.0f..volume_steps) don't leave a value a
sentinel could safely claim as "never computed yet".

Direct callers of `calculateVolumeLimits()` (`setVolume()`, `setBalance()`, `setVolumeSteps()`,
init) are untouched -- they still recompute immediately when the API is called. The cache is
simply stale by one tick afterward, which `gain_ramp()`'s own next call self-corrects at the
cost of one harmless extra recompute.

## Why it's correct

The function being skipped conditionally is exactly the one whose own comment already states
the condition (`// is calculated when the volume or balance changes`) -- this makes the call
site honour a contract the function already documented. Nothing about the fade math itself
changes: `gain_ramp()`'s ramp/clamp logic above the cache check is untouched, so fade timing and
step size are identical to before.

## Verification (hardware, ESP32-S3, I2S output)

Full detail and raw numbers: #1385.

- **Motivating measurement**: fully disabling the `gain_ramp()`->`calculateVolumeLimits()` call
  dropped the internal `audioTask` from 41.9% to 27.3% of a core on mp3, 51.7% to 39.9% on flac
  -- establishing the size of the problem (11-15 points of a core at rest).
- **This fix's actual saving**, measured separately from the ablation above: mp3 27.6% vs 27.3%
  full-disable, flac 39.8% vs 39.9% -- i.e. at rest it skips essentially every tick, matching
  the "steady state is the overwhelming majority of the time" premise.
- **Fade correctness checked directly**: a tick that has to recompute (a real volume change)
  still runs the full computation (589 us measured); a settled tick does not (29 us,
  comparison-only). Final volume settles at exactly the requested value. No crashes, no error
  lines, device stayed responsive throughout.
- **Per-codec breakdown** (7 codecs, wav/mp3/flac/aac/m4a/ogg/opus, 60-second windows each):
  `gainRamp`'s own share dropped to ~0.01-0.33% of a core on every codec post-fix, from
  10.66-16.56% pre-fix on the three codecs first measured.
- Not yet done: a listening test of fade smoothness by ear. The fix doesn't touch the ramp rate
  or step size, only skips the limiter recompute when the ramp has nothing new to report, so no
  audible difference is expected -- but the volume path is audio-sensitive code and I'd rather
  say plainly what hasn't been checked than imply it has.

## Disclosure

Drafted with AI assistance (Claude) based on hardware measurements I performed and verified
myself. Opening as a draft while I give it one more read-through; will mark ready for review
shortly.
