### PR TITLE
Fix out-of-bounds access in stereo2mono()

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -7351,7 +7351,7 @@ uint32_t Audio::getInBufferSize() {
 // —————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void Audio::stereo2mono(int32_t* buff, size_t len) {
 
-    for (uint16_t i = 0; i < len * 2; i += 2) {
+    for (size_t i = 0; i + 1 < len; i += 2) {
         int64_t l = buff[i];
         int64_t r = buff[i + 1];
         int32_t m = (int32_t)((l + r) >> 1); // average, without overflow


### PR DESCRIPTION
## Description

This PR fixes an out-of-bounds memory access in `stereo2mono()` when `forceMono(true)` is enabled.

The problem was discovered while investigating ESPuino devices that rebooted instead of entering deep sleep when switched off during audio playback.

Related ESPuino discussion:

https://forum.espuino.de/t/absturz-beim-beenden/4724

## Symptoms

With forced mono enabled, audio playback corrupts the heap. The corruption may only be detected later when audio buffers are released during shutdown:

```text
Going to deep sleep now!
shutdown webserver..
shutdown audioplayer..

CORRUPT HEAP: Bad head at 0x3f8808cc.
Expected 0xabba1234 got 0xd5dd115a

assert failed: multi_heap_free multi_heap_poisoning.c:279
```

The device can also crash during active playback before shutdown:

```text
Guru Meditation Error: Core 0 panic'ed (LoadProhibited).
Exception was unhandled.
```

Forced stereo playback does not trigger the problem.

## Root cause

`playChunk()` determines the number of valid `int32_t` words in the working buffer:

```cpp
size_t readWords = std::min(SamplesBuff.bufferFilled(), m_work_words);
readWords &= ~static_cast<size_t>(1);

SamplesBuff.peek(m_i2sWorkBuff.get(), readWords);
```

It passes this word count directly to `stereo2mono()`:

```cpp
stereo2mono(m_i2sWorkBuff.get(), readWords);
```

Therefore, the `len` argument already represents the number of valid `int32_t` words in `buff`, including both left and right channel words.

The previous loop multiplied this length by two:

```cpp
for (uint16_t i = 0; i < len * 2; i += 2)
```

For example, when `len` is `6`, the valid indices are `0` through `5`:

```text
Index:    0  1  2  3  4  5
Channel:  L  R  L  R  L  R
```

The previous loop processed these index pairs:

```text
0/1, 2/3, 4/5, 6/7, 8/9, 10/11
```

Only the first three pairs are valid. The remaining iterations write beyond the end of the supplied buffer and corrupt adjacent memory.

## Fix

The loop now uses the supplied word count directly:

```cpp
for (size_t i = 0; i + 1 < len; i += 2)
```

The `i + 1 < len` condition ensures that both the left and right channel words are available before processing a stereo frame.

Using `size_t` for the index also matches the type of the `len` argument.

## Testing

The original heap corruption was reproduced with:

* ESPuino on an ESP32 with PSRAM
* Arduino Core 3.3.11
* ESP-IDF 5.5.5
* MP3 playback
* `forceMono(true)`

The change has not been tested across all targets and audio formats supported by ESP32-audioI2S.


Fixes #1390